### PR TITLE
ci: replace deprecated home-assistant/builder with build-image actions

### DIFF
--- a/.github/workflows/build-addon.yml
+++ b/.github/workflows/build-addon.yml
@@ -133,6 +133,16 @@ jobs:
           echo "EOF"
         } >> "$GITHUB_OUTPUT"
 
+    # build-image only logs in when pushing. Authenticate unconditionally so
+    # that buildx can probe the registry build cache on non-pushing (test)
+    # builds without hitting an anonymous 403.
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Build addon image
       id: build
       uses: home-assistant/builder/actions/build-image@62a1597b84b3461abad9816d9cd92862a2b542c3 # 2026.03.2

--- a/.github/workflows/build-addon.yml
+++ b/.github/workflows/build-addon.yml
@@ -24,35 +24,56 @@ on:
 
 env:
   REGISTRY: ghcr.io
+  REGISTRY_PREFIX: ghcr.io/${{ github.repository_owner }}
+  ARCHITECTURES: '["amd64", "aarch64"]'
 
 jobs:
+  # Determine which addons to build based on the build type. The output is a
+  # JSON array consumed by the build and manifest job matrices.
+  setup:
+    name: Determine addons
+    runs-on: ubuntu-latest
+    outputs:
+      addons: ${{ steps.addons.outputs.addons }}
+    steps:
+      - name: Select addons for build type
+        id: addons
+        env:
+          BUILD_TYPE: ${{ inputs.build-type }}
+        run: |
+          case "${BUILD_TYPE}" in
+            release) addons='["rtl_433", "rtl_433_mqtt_autodiscovery"]' ;;
+            nightly) addons='["rtl_433-next", "rtl_433_mqtt_autodiscovery-next"]' ;;
+            test)    addons='["rtl_433", "rtl_433-next", "rtl_433_mqtt_autodiscovery", "rtl_433_mqtt_autodiscovery-next"]' ;;
+            *)
+              echo "::error::Unknown build-type: ${BUILD_TYPE}"
+              exit 1
+              ;;
+          esac
+          echo "addons=${addons}" >> "$GITHUB_OUTPUT"
+
+  # Build one single-arch image per (addon, arch). aarch64 builds run on native
+  # ARM runners (no QEMU emulation). Images are pushed and signed with Cosign
+  # for every build type except "test".
   build:
     name: Build ${{ matrix.addon }} (${{ matrix.arch }})
-    runs-on: ${{ matrix.runner }}
+    needs: setup
+    runs-on: ${{ matrix.os }}
     # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
     permissions:
       contents: read
-      packages: write
-      attestations: write
-      id-token: write
+      packages: write # push images to GitHub Container Registry
+      id-token: write # Cosign keyless signing (issue OIDC token)
     strategy:
+      fail-fast: false
       matrix:
+        addon: ${{ fromJSON(needs.setup.outputs.addons) }}
         arch: [amd64, aarch64]
-        addon: [rtl_433, rtl_433-next, rtl_433_mqtt_autodiscovery, rtl_433_mqtt_autodiscovery-next]
         include:
           - arch: amd64
-            runner: ubuntu-24.04
-            builder_image: amd64
+            os: ubuntu-24.04
           - arch: aarch64
-            runner: ubuntu-24.04-arm
-            builder_image: aarch64
-        exclude:
-          # release builds only stable addons
-          - addon: ${{ inputs.build-type == 'release' && 'rtl_433-next' || '' }}
-          - addon: ${{ inputs.build-type == 'release' && 'rtl_433_mqtt_autodiscovery-next' || '' }}
-          # nightly builds only -next addons
-          - addon: ${{ inputs.build-type == 'nightly' && 'rtl_433' || '' }}
-          - addon: ${{ inputs.build-type == 'nightly' && 'rtl_433_mqtt_autodiscovery' || '' }}
+            os: ubuntu-24.04-arm
 
     steps:
     - name: Checkout the repository
@@ -60,94 +81,115 @@ jobs:
       with:
         ref: ${{ inputs.checkout-ref || github.ref }}
 
-    - name: Make sure tag doesn't exist
-      if: inputs.build-type == 'release' && !inputs.skip-tag-check
-      run: |
-        set -e
-        sudo apt-get update
-        sudo apt-get install -y jq
-        set -x
-        TAG=$(jq '.version' < rtl_433/config.json)
-        ! docker manifest inspect "ghcr.io/${{ github.repository}}-${{ matrix.addon }}-${{ matrix.arch }}:$TAG" > /dev/null
-
     - name: Inject slug/short variables
       uses: rlespinasse/github-slug-action@e6f261660910b273384c5c42b17a0217881b217a # v5
 
-    - name: Login to Packages Container registry
-      uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
-      with:
-        registry: ${{ env.REGISTRY }}
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+    - name: Copy shared files into -next variants
+      env:
+        ADDON: ${{ matrix.addon }}
+      run: |
+        case "${ADDON}" in
+          rtl_433-next)
+            cp -nv -R rtl_433/* "${ADDON}/" ;;
+          rtl_433_mqtt_autodiscovery-next)
+            cp -nv -R rtl_433_mqtt_autodiscovery/* "${ADDON}/" ;;
+        esac
 
     - name: Determine image version
       id: version
+      env:
+        BUILD_TYPE: ${{ inputs.build-type }}
+        ADDON: ${{ matrix.addon }}
       run: |
-        if [ "${{ inputs.build-type }}" == "release" ]; then
-          # For release builds, get version from config.json
-          # Use the base addon directory (without -next suffix)
-          BASE_ADDON="${{ matrix.addon }}"
-          BASE_ADDON="${BASE_ADDON%-next}"
-          VERSION=$(jq -r '.version' < "${BASE_ADDON}/config.json")
-        elif [ "${{ inputs.build-type }}" == "nightly" ]; then
-          VERSION="next"
-        else
-          VERSION="${{ env.GITHUB_REF_SLUG }}"
-        fi
-        IMAGE_NAME="${{ env.REGISTRY }}/${{ github.repository }}-${{ matrix.addon }}-${{ matrix.arch }}"
+        case "${BUILD_TYPE}" in
+          release) version=$(jq -r '.version' "${ADDON}/config.json") ;;
+          nightly) version="next" ;;
+          *)       version="${GITHUB_REF_SLUG}" ;;
+        esac
+        echo "version=${version}" >> "$GITHUB_OUTPUT"
+
+    - name: Make sure tag doesn't exist
+      if: inputs.build-type == 'release' && !inputs.skip-tag-check
+      env:
+        IMAGE: ${{ env.REGISTRY_PREFIX }}/${{ matrix.addon }}
+        TAG: ${{ steps.version.outputs.version }}
+      run: |
+        ! docker manifest inspect "${IMAGE}:${TAG}" > /dev/null
+
+    - name: Read addon build configuration
+      id: buildconf
+      env:
+        ADDON: ${{ matrix.addon }}
+        ARCH: ${{ matrix.arch }}
+      run: |
+        # The legacy home-assistant/builder action read build.json implicitly.
+        # build-image only injects BUILD_ARCH/BUILD_VERSION, so pass BUILD_FROM
+        # and any extra build args (e.g. rtl433GitRevision) from build.json here.
+        build_from=$(jq -r --arg arch "${ARCH}" '.build_from[$arch]' "${ADDON}/build.json")
         {
-          echo "version=${VERSION}"
-          echo "image_name=${IMAGE_NAME}"
-          echo "full_image=${IMAGE_NAME}:${VERSION}"
+          echo "build_args<<EOF"
+          echo "BUILD_FROM=${build_from}"
+          jq -r '.args // {} | to_entries[] | "\(.key)=\(.value)"' "${ADDON}/build.json"
+          echo "EOF"
         } >> "$GITHUB_OUTPUT"
-
-    - name: Extract metadata (tags, labels) for Docker
-      id: meta
-      uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6
-      with:
-        images: ${{ steps.version.outputs.image_name }}
-        tags: |
-          type=raw,value=${{ steps.version.outputs.version }}
-
-    - name: Copy files for next addon variants
-      run: |
-        if [ "${{ matrix.addon }}" == "rtl_433-next" ]; then
-          cp -nv -R rtl_433/* ${{ matrix.addon }}/
-        fi
-        if [ "${{ matrix.addon }}" == "rtl_433_mqtt_autodiscovery-next" ]; then
-          cp -nv -R rtl_433_mqtt_autodiscovery/* ${{ matrix.addon }}/
-        fi
 
     - name: Build addon image
       id: build
-      uses: home-assistant/builder@master
+      uses: home-assistant/builder/actions/build-image@62a1597b84b3461abad9816d9cd92862a2b542c3 # 2026.03.2
       with:
-        image: ${{ matrix.builder_image }}
-        args: |
-          --${{ matrix.arch }} \
-          --docker-hub $REGISTRY \
-          --image ${{ github.repository}}-${{ matrix.addon }}-{arch} \
-          --no-latest \
-          --target ${{ matrix.addon }} \
-          ${{ inputs.build-type == 'test' && '--test --self-cache --version' || '' }} \
-          ${{ inputs.build-type == 'test' && env.GITHUB_REF_SLUG || '' }} \
-          ${{ inputs.build-type == 'nightly' && '--version next' || '' }}
+        arch: ${{ matrix.arch }}
+        image: ${{ env.REGISTRY_PREFIX }}/${{ matrix.arch }}-${{ matrix.addon }}
+        image-tags: ${{ steps.version.outputs.version }}
+        version: ${{ steps.version.outputs.version }}
+        context: ${{ matrix.addon }}
+        build-args: ${{ steps.buildconf.outputs.build_args }}
+        container-registry: ${{ env.REGISTRY }}
+        container-registry-password: ${{ secrets.GITHUB_TOKEN }}
+        push: ${{ inputs.build-type != 'test' }}
+        cosign: ${{ inputs.build-type != 'test' }}
+        cache-gha-scope: ${{ matrix.addon }}
+        cache-image-tag: ${{ steps.version.outputs.version }}
 
-    - name: Get image digest
-      id: digest
-      if: inputs.build-type != 'test'
+  # Combine the per-arch images into a single multi-arch manifest per addon and
+  # sign it with Cosign. Skipped for "test" builds, which never push images.
+  manifest:
+    name: Publish ${{ matrix.addon }} manifest
+    needs: [setup, build]
+    if: inputs.build-type != 'test'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # checkout to read config.json versions
+      packages: write # push the manifest to GitHub Container Registry
+      id-token: write # Cosign keyless signing (issue OIDC token)
+    strategy:
+      fail-fast: false
+      matrix:
+        addon: ${{ fromJSON(needs.setup.outputs.addons) }}
+
+    steps:
+    - name: Checkout the repository
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      with:
+        ref: ${{ inputs.checkout-ref || github.ref }}
+
+    - name: Determine image version
+      id: version
+      env:
+        BUILD_TYPE: ${{ inputs.build-type }}
+        ADDON: ${{ matrix.addon }}
       run: |
-        DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' "${{ steps.version.outputs.full_image }}" | cut -d'@' -f2)
-        echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
-        echo "Image digest: ${DIGEST}"
+        case "${BUILD_TYPE}" in
+          release) version=$(jq -r '.version' "${ADDON}/config.json") ;;
+          *)       version="next" ;;
+        esac
+        echo "version=${version}" >> "$GITHUB_OUTPUT"
 
-    # This step generates an artifact attestation for the image, which is an unforgeable
-    # statement about where and how it was built. It increases supply chain security for
-    # people who consume the image.
-    - name: Generate artifact attestation
-      if: inputs.build-type != 'test'
-      uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4
+    - name: Publish multi-arch manifest
+      uses: home-assistant/builder/actions/publish-multi-arch-manifest@62a1597b84b3461abad9816d9cd92862a2b542c3 # 2026.03.2
       with:
-        subject-name: ${{ steps.version.outputs.image_name }}
-        subject-digest: ${{ steps.digest.outputs.digest }}
-        push-to-registry: true
+        architectures: ${{ env.ARCHITECTURES }}
+        registry-prefix: ${{ env.REGISTRY_PREFIX }}
+        container-registry: ${{ env.REGISTRY }}
+        container-registry-password: ${{ secrets.GITHUB_TOKEN }}
+        image-name: ${{ matrix.addon }}
+        image-tags: ${{ steps.version.outputs.version }}

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -18,7 +18,6 @@ jobs:
     permissions:
       contents: read
       packages: write
-      attestations: write
       id-token: write
     with:
       build-type: test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,6 @@ jobs:
     permissions:
       contents: read
       packages: write
-      attestations: write
       id-token: write
     with:
       build-type: release
@@ -43,7 +42,6 @@ jobs:
     permissions:
       contents: read
       packages: write
-      attestations: write
       id-token: write
     with:
       build-type: nightly

--- a/rtl_433-next/config.json
+++ b/rtl_433-next/config.json
@@ -1,6 +1,6 @@
 {
   "name": "rtl_433 (next)",
-  "image": "ghcr.io/pbkhrv/rtl_433-hass-addons-rtl_433-next-{arch}",
+  "image": "ghcr.io/rtl-433-hass/rtl_433-next",
   "version": "next",
   "slug": "rtl433-next",
   "description": "Receive wireless sensor data via an SDR dongle and rtl_433",

--- a/rtl_433/config.json
+++ b/rtl_433/config.json
@@ -1,6 +1,6 @@
 {
   "name": "rtl_433",
-  "image": "ghcr.io/pbkhrv/rtl_433-hass-addons-rtl_433-{arch}",
+  "image": "ghcr.io/rtl-433-hass/rtl_433",
   "version": "next",
   "slug": "rtl433",
   "description": "Receive wireless sensor data via an SDR dongle and rtl_433",

--- a/rtl_433_mqtt_autodiscovery-next/config.json
+++ b/rtl_433_mqtt_autodiscovery-next/config.json
@@ -1,6 +1,6 @@
 {
   "name": "rtl_433 MQTT Auto Discovery (next)",
-  "image": "ghcr.io/pbkhrv/rtl_433-hass-addons-rtl_433_mqtt_autodiscovery-next-{arch}",
+  "image": "ghcr.io/rtl-433-hass/rtl_433_mqtt_autodiscovery-next",
   "version": "next",
   "slug": "rtl433mqttautodiscovery-next",
   "description": "Automatic discovery of rtl_433 device information via MQTT",

--- a/rtl_433_mqtt_autodiscovery/README.md
+++ b/rtl_433_mqtt_autodiscovery/README.md
@@ -112,10 +112,10 @@ The following options apply to all broker configurations:
 Follow these steps to run just the autodiscovery script in a dedicated container. For this setup, we recommend using the [hertzg/rtl_433_docker](https://github.com/hertzg/rtl_433_docker) images to run `rtl_433` itself.
 
 ```
-docker run -e MQTT_HOST=mqtt.example.com -e MQTT_USERNAME=username -e MQTT_PASSWORD=password ghcr.io/pbkhrv/rtl_433-hass-addons-rtl_433_mqtt_autodiscovery-amd64
+docker run -e MQTT_HOST=mqtt.example.com -e MQTT_USERNAME=username -e MQTT_PASSWORD=password ghcr.io/rtl-433-hass/rtl_433_mqtt_autodiscovery
 ```
 
-Replace `amd64` with your appropriate architecture. For Raspberry Pi, this is `armhf`, `armv7`, or `aarch64` depending on your Pi version and operating system. If unsure, running `arch` at the command line can help identify the architecture.
+The image is a multi-arch manifest, so Docker automatically pulls the variant matching your machine's architecture.
 
 Using docker-compose:
 
@@ -124,7 +124,7 @@ version: '3'
 services:
   rtl_433_autodiscovery:
     container_name: rtl_433_autodiscovery
-    image: ghcr.io/pbkhrv/rtl_433-hass-addons-rtl_433_mqtt_autodiscovery-amd64 # On Raspberry Pi replace `amd64` with the appropriate architecture.
+    image: ghcr.io/rtl-433-hass/rtl_433_mqtt_autodiscovery # multi-arch manifest; Docker selects the right architecture automatically.
     environment:
       - MQTT_HOST=mqtt.example.com
       - MQTT_USERNAME=username

--- a/rtl_433_mqtt_autodiscovery/config.json
+++ b/rtl_433_mqtt_autodiscovery/config.json
@@ -1,6 +1,6 @@
 {
   "name": "rtl_433 MQTT Auto Discovery",
-  "image": "ghcr.io/pbkhrv/rtl_433-hass-addons-rtl_433_mqtt_autodiscovery-{arch}",
+  "image": "ghcr.io/rtl-433-hass/rtl_433_mqtt_autodiscovery",
   "version": "next",
   "slug": "rtl433mqttautodiscovery",
   "description": "Automatic discovery of rtl_433 device information via MQTT",


### PR DESCRIPTION
## Why

`home-assistant/builder@master` is deprecated and no longer works (last release `2026.02.1`). The [builder repo](https://github.com/home-assistant/builder) now ships composable actions. This migrates the build to them and modernizes image publishing.

## What changed

**Workflow (`ci:` commit)**
- Reusable `build-addon.yml` now uses `home-assistant/builder/actions/build-image` + `publish-multi-arch-manifest`, pinned to `2026.03.2`.
- New `setup` job picks the addon list per build-type (test/release/nightly), replacing the matrix-exclude hacks.
- `aarch64` still builds natively on `ubuntu-24.04-arm` (no QEMU) — this was already in place and is preserved.
- `build-image` doesn't read `build.json` implicitly, so a step extracts `BUILD_FROM` (per arch) and extra build args (e.g. `rtl433GitRevision`) and passes them via `build-args`.
- **Signing:** switched from the bespoke `attest-build-provenance` step to the builder's native **Cosign** keyless signing (per-arch images + the manifest). The now-unused `attestations: write` permission is dropped from the caller workflows.

**Images (`build:` commit)**
- Adopted standard multi-arch **manifest** image names: `ghcr.io/rtl-433-hass/<addon>` (per-arch images are `<arch>-<addon>`).
- Updated each `config.json` `image` to the manifest name (dropping the `{arch}` placeholder — HA/Docker resolves arch from the manifest).
- Reconciled a pre-existing mismatch: CI published to `ghcr.io/rtl-433-hass/...` while `config.json` still pointed at `ghcr.io/pbkhrv/...`.
- Updated the standalone docker run/compose examples in the MQTT add-on README.

## ⚠️ Breaking change
Published image names change. Existing installs referencing the old `ghcr.io/pbkhrv/rtl_433-hass-addons-<addon>-<arch>` names must re-pull. The first stable release after merge will populate the new manifest tags.

## Validation
`actionlint` + `shellcheck` clean on all workflows; all `config.json` files valid JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
