### PR TITLE
build(rtl_433): stop pinning Alpine package versions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,28 +9,6 @@
     {
       "matchPackageNames": ["merbanan/rtl_433"],
       "semanticCommitType": "feat"
-    },
-    {
-      "matchDatasources": ["repology"],
-      "automerge": true
-    },
-    {
-      "groupName": "Docker",
-      "matchDatasources": ["repology"],
-      "automerge": true,
-      "matchPackageNames": ["/^alpine_.*/docker.*$/"]
-    },
-    {
-      "groupName": "OpenSSL",
-      "matchDatasources": ["repology"],
-      "automerge": true,
-      "matchPackageNames": ["/^alpine_.*/openssl.*$/"]
-    },
-    {
-      "groupName": "Python",
-      "matchDatasources": ["repology"],
-      "automerge": true,
-      "matchPackageNames": ["/^alpine_.*/python3(-dev)?$/"]
     }
   ],
   "customManagers": [
@@ -75,17 +53,6 @@
       ],
       "depNameTemplate": "ubuntu",
       "datasourceTemplate": "github-runners"
-    },
-    {
-      "customType": "regex",
-      "managerFilePatterns": ["/Dockerfile$/"],
-      "matchStringsStrategy": "any",
-      "matchStrings": [
-        "\\s\\s(?<package>[a-z0-9][a-z0-9-_]+)=(?<currentValue>[a-z0-9-_.]+)\\s+"
-      ],
-      "versioningTemplate": "loose",
-      "datasourceTemplate": "repology",
-      "depNameTemplate": "alpine_3_21/{{package}}"
     }
   ]
 }

--- a/rtl_433/Dockerfile
+++ b/rtl_433/Dockerfile
@@ -5,17 +5,21 @@ FROM $BUILD_FROM as builder
 ENV LANG C.UTF-8
 
 # Copied with minor edits from https://github.com/hertzg/rtl_433_docker/blob/master/images/alpine/build-context/Dockerfile
+# DL3018 (pin apk versions) is ignored on purpose: Alpine removes superseded
+# package versions from its repos, so exact pins break the build as soon as a
+# patch ships upstream.
+# hadolint ignore=DL3018
 RUN apk add --no-cache --virtual .buildDeps \
-    build-base=0.5-r3 \
-    libusb-dev=1.0.27-r0 \
-    hackrf=2024.02.1-r0 \
-    hackrf-dev=2024.02.1-r0 \
-    librtlsdr-dev=2.0.2-r0 \
-    soapy-sdr=0.8.1-r3 \
-    soapy-sdr-dev=0.8.1-r3 \
-    openssl-dev=3.3.6-r0 \
-    cmake=3.31.1-r0 \
-    git=2.47.3-r0
+    build-base \
+    libusb-dev \
+    hackrf \
+    hackrf-dev \
+    librtlsdr-dev \
+    soapy-sdr \
+    soapy-sdr-dev \
+    openssl-dev \
+    cmake \
+    git
 
 WORKDIR /build
 
@@ -56,12 +60,16 @@ FROM $BUILD_FROM
 
 ENV LANG C.UTF-8
 
+# DL3018 (pin apk versions) is ignored on purpose: Alpine removes superseded
+# package versions from its repos, so exact pins break the build as soon as a
+# patch ships upstream.
+# hadolint ignore=DL3018
 RUN apk add --no-cache \
-    libusb=1.0.27-r0 \
-    hackrf=2024.02.1-r0 \
-    librtlsdr=2.0.2-r0 \
-    soapy-sdr=0.8.1-r3 \
-    sed=4.9-r2
+    libusb \
+    hackrf \
+    librtlsdr \
+    soapy-sdr \
+    sed
 WORKDIR /root
 COPY --from=rtl_433_builder /build/root/ /
 


### PR DESCRIPTION
## Why

Alpine keeps **only the latest build of each package** per release branch on its CDN. When a package gets a patch bump (e.g. `openssl-dev` 3.3.6-r0 → 3.3.7-r0), the old `.apk` is dropped, and since `apk add` fetches from the live CDN at build time, an exact pin like `openssl-dev=3.3.6-r0` becomes unsatisfiable and the build fails. This broke the scheduled `rtl_433` builds for ~5 days (2026-05-25 → 05-30).

Exact pins also never delivered real reproducibility here — that would require a frozen package mirror plus a digest-pinned base image, not just version strings.

## What changed

- **`rtl_433/Dockerfile`** — drop the exact `=version` pins from both `apk add` invocations (build-deps and runtime). Each now carries a `# hadolint ignore=DL3018` with an inline comment explaining *why* the packages are intentionally unpinned.
- **`renovate.json`** — remove the now-dead automation: the custom manager that tracked `package=version` pins in Dockerfiles, and the `repology` packageRules (the catch-all plus the Docker/OpenSSL/Python groups).

## Out of scope (unchanged)

Renovate still manages **GitHub Action digests, pre-commit hook versions, the upstream rtl_433 revision, and ubuntu runner versions**. The `mqtt_autodiscovery` add-on has no apk pins (it's Python-based), so it's untouched.

## Trade-off

Builds will now pull whatever Alpine 3.21 currently ships, so they stay green through patch bumps but are no longer pinned to exact versions. This is the deliberate choice from the PR #54 discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
