### PR TITLE
style: uppercase AS in Dockerfile FROM stage aliases

### DIFF
--- a/rtl_433/Dockerfile
+++ b/rtl_433/Dockerfile
@@ -1,6 +1,6 @@
 ARG BUILD_FROM=ghcr.io/home-assistant/amd64-base:3.21
 # hadolint ignore=DL3006
-FROM $BUILD_FROM as builder
+FROM $BUILD_FROM AS builder
 
 ENV LANG C.UTF-8
 
@@ -23,7 +23,7 @@ RUN apk add --no-cache --virtual .buildDeps \
 
 WORKDIR /build
 
-FROM builder as rtl_433_builder
+FROM builder AS rtl_433_builder
 
 RUN git clone https://github.com/merbanan/rtl_433
 WORKDIR /build/rtl_433
@@ -42,7 +42,7 @@ WORKDIR /build/root
 WORKDIR /build/rtl_433/build
 RUN make DESTDIR=/build/root/ install
 
-FROM builder as soapy_hackrf_builder
+FROM builder AS soapy_hackrf_builder
 RUN git clone https://github.com/pothosware/SoapyHackRF.git
 WORKDIR /build/SoapyHackRF
 # hadolint ignore=DL3059

--- a/rtl_433_mqtt_autodiscovery/Dockerfile
+++ b/rtl_433_mqtt_autodiscovery/Dockerfile
@@ -1,6 +1,6 @@
 ARG BUILD_FROM=ghcr.io/home-assistant/amd64-base-python:3.12-alpine3.21
 # hadolint ignore=DL3006
-FROM ${BUILD_FROM} as builder
+FROM ${BUILD_FROM} AS builder
 
 ARG rtl433GitRevision=25.12
 


### PR DESCRIPTION
## Why

BuildKit logs a `FromAsCasing` warning whenever a `FROM` line mixes casing with its stage keyword:

```
FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 3)
```

## What changed

Capitalize `as` → `AS` in every multi-stage alias across both add-on Dockerfiles:

- `rtl_433/Dockerfile` — `builder`, `rtl_433_builder`, `soapy_hackrf_builder`
- `rtl_433_mqtt_autodiscovery/Dockerfile` — `builder`

Purely cosmetic; no build behavior changes. hadolint passes on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
