### PR TITLE
ci: scope concurrency groups per workflow to stop cross-workflow cancellation

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 concurrency:
-  group: ${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ on:
     - cron: '16 8 * * *'
 
 concurrency:
-  group: ${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Problem

Every push to `main` triggers two workflows — `builder.yml` ("Build rtl_433 images", test build) and `release.yml` ("Create new rtl_433 addon release", nightly build). Both declared the same concurrency group `${{ github.ref }}`.

Concurrency groups are **repository-global, not per-workflow**, so on a push to main both workflows landed in the group `refs/heads/main` with `cancel-in-progress: true` and cancelled each other:

> `Canceling since a higher priority waiting request for refs/heads/main exists`

This surfaced as `cancelled` jobs and a failed overall commit status. The unexpanded `${{ matrix.addon }}` strings in job names were a downstream symptom — a job cancelled before its matrix expands never gets its name substituted.

## Fix

Scope each workflow's concurrency group to itself with `${{ github.workflow }}-${{ github.ref }}`. Both workflows now run to completion on a push to main, while each still cancels its own superseded runs.

## Notes

- Draft: leaving CI to confirm both workflows now coexist on push to main.
- Not addressed here (design choice): on push to main, both a non-pushing `test` build and the `nightly` build run with overlapping work. Could gate `builder.yml` to PRs only if that's wasteful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)