### PR TITLE
feat(rtl_433): remove stale Supervisor discovery when no radios are present

### DIFF
--- a/rtl_433/run.sh
+++ b/rtl_433/run.sh
@@ -41,6 +41,11 @@ RADIO_HEALTHY_UPTIME=60
 # be exercised against a mock tree in tests.
 SYSFS_USB_BASE="${SYSFS_USB_BASE:-/sys/bus/usb/devices}"
 
+# Per-add-on persistent storage (the always-present '/data' volume). Used to
+# remember the Supervisor discovery message's uuid across restarts so a later
+# run with no radios can delete it. Overridable so tests can use a temp dir.
+DATA_DIR="${DATA_DIR:-/data}"
+
 # Known RTL-SDR USB VID:PID identifiers (from librtlsdr's known-device table),
 # stored space-padded so a membership test is a simple glob. Used to pick out
 # RTL-SDR dongles while enumerating sysfs.
@@ -463,35 +468,45 @@ main() {
             return 0
         fi
 
-        local i port tag uid body http_code
+        local i port tag uid body response http_code resp_body msg_uuid published_uuid=""
         for i in "${!radio_ports[@]}"
         do
             port="${radio_ports[$i]}"
             tag="${radio_tags[$i]}"
             uid="${radio_unique_ids[$i]}"
 
-            # Build the discovery payload with printf (jq is not in the runtime
-            # image). 'service' MUST equal the discovery entry in config.json
-            # ("rtl_433"). The integration connects to ws://<host>:<port>/ws and uses
-            # 'unique_id' as a stable per-radio key. host/port are interpolated; the
-            # unique_id is pre-sanitised to a JSON-safe character set by
-            # resolve_radio_unique_id, so no further JSON escaping is needed.
+            # Build the discovery payload with printf (parsed with sed below, to
+            # match how the Supervisor JSON is handled elsewhere here). 'service'
+            # MUST equal the discovery entry in config.json ("rtl_433"). The
+            # integration connects to ws://<host>:<port>/ws and uses 'unique_id' as
+            # a stable per-radio key. host/port are interpolated; the unique_id is
+            # pre-sanitised to a JSON-safe character set by resolve_radio_unique_id,
+            # so no further JSON escaping is needed.
             printf -v body \
                 '{"service": "rtl_433", "config": {"host": "%s", "port": %s, "path": "/ws", "secure": false, "unique_id": "%s"}}' \
                 "$host" "$port" "$uid"
 
-            # Best-effort POST. Capture the HTTP status separately from the body so
-            # a non-2xx response or a curl failure is logged but never aborts the
-            # script. -o /dev/null discards the response body.
-            http_code="$(curl -s -o /dev/null -w '%{http_code}' \
+            # Best-effort POST. Capture the response body and the HTTP status (the
+            # latter appended on its own trailing line) so a non-2xx response or a
+            # curl failure is logged but never aborts the script. The body carries
+            # the message uuid, which we persist so a later run with no radios can
+            # delete the message.
+            response="$(curl -s -w $'\n%{http_code}' \
                 -X POST \
                 -H "Authorization: Bearer ${SUPERVISOR_TOKEN}" \
                 -H "Content-Type: application/json" \
                 -d "$body" \
-                "http://supervisor/discovery" 2>/dev/null)" || http_code="000"
+                "http://supervisor/discovery" 2>/dev/null)" || response=$'\n000'
+            http_code="${response##*$'\n'}"
+            resp_body="${response%$'\n'*}"
 
             if [[ "$http_code" =~ ^2 ]]
             then
+                # All radios share one Supervisor discovery message (equality is
+                # add-on + service, so each POST overwrites the same message and
+                # returns the same uuid); remember it for cleanup.
+                msg_uuid="$(printf '%s' "$resp_body" | sed -n 's/.*"uuid"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')"
+                [ -n "$msg_uuid" ] && published_uuid="$msg_uuid"
                 bashio::log.info "Published discovery for radio '${tag}' on port ${port} (HTTP ${http_code})."
             else
                 # The Supervisor may reject the 'rtl_433' service until the
@@ -500,9 +515,62 @@ main() {
                 bashio::log.warning "Discovery publication for radio '${tag}' on port ${port} returned HTTP ${http_code} (non-fatal; Supervisor may reject the service until the integration supports discovery)."
             fi
         done
+
+        # Persist the discovery message uuid so a later boot with no radios can
+        # delete it (see remove_discovery_state). Best-effort: a write failure is
+        # logged but never fatal.
+        if [ -n "$published_uuid" ]
+        then
+            printf '%s' "$published_uuid" > "${DATA_DIR}/discovery.uuid" 2>/dev/null \
+                || bashio::log.warning "Could not persist discovery uuid to ${DATA_DIR}/discovery.uuid."
+        fi
     }
 
-    publish_discovery
+    # Remove a previously-published discovery message when this run has no radios
+    # to advertise (e.g. the last/only dongle was unplugged), so Home Assistant
+    # stops trying to reach a radio that is no longer present. All radios share a
+    # single Supervisor discovery message (keyed by add-on + 'rtl_433' service),
+    # so there is at most one uuid to delete, remembered in DATA_DIR by
+    # publish_discovery. Best-effort: any failure is logged and ignored.
+    remove_discovery_state() {
+        if [ -z "${SUPERVISOR_TOKEN:-}" ]
+        then
+            return 0
+        fi
+
+        local state="${DATA_DIR}/discovery.uuid" uuid http_code
+        [ -f "$state" ] || return 0
+        uuid="$(cat "$state" 2>/dev/null)"
+        if [ -z "$uuid" ]
+        then
+            rm -f "$state"
+            return 0
+        fi
+
+        http_code="$(curl -s -o /dev/null -w '%{http_code}' \
+            -X DELETE \
+            -H "Authorization: Bearer ${SUPERVISOR_TOKEN}" \
+            "http://supervisor/discovery/${uuid}" 2>/dev/null)" || http_code="000"
+
+        if [[ "$http_code" =~ ^2 ]]
+        then
+            bashio::log.info "Removed stale rtl_433 discovery message (uuid ${uuid}, HTTP ${http_code}); no radios are running."
+        else
+            # A 404 just means the message was already gone (e.g. the Supervisor
+            # purged it); either way the local state is cleared below.
+            bashio::log.warning "Removal of stale discovery uuid ${uuid} returned HTTP ${http_code} (non-fatal)."
+        fi
+        rm -f "$state"
+    }
+
+    # Advertise the running radios, or clean up a leftover discovery message when
+    # there are none.
+    if [ "${#radio_ports[@]}" -gt 0 ]
+    then
+        publish_discovery
+    else
+        remove_discovery_state
+    fi
 
     # Block until shutdown. Each supervisor restarts its own rtl_433, so under
     # normal operation the supervisor PIDs never exit and the add-on stays up; a

--- a/rtl_433/run.sh
+++ b/rtl_433/run.sh
@@ -215,6 +215,61 @@ supervise_radio() {
     done
 }
 
+# Extract the discovery message uuid from a Supervisor 'POST /discovery' response
+# body. Prints the uuid (empty if absent). Pure string parsing with sed, matching
+# how the rest of this script reads Supervisor JSON. Args: <response_body>.
+parse_discovery_uuid() {
+    printf '%s' "$1" | sed -n 's/.*"uuid"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p'
+}
+
+# Persist the Supervisor discovery message uuid under DATA_DIR so a later run with
+# no radios can delete it (see remove_discovery_state). No-op for an empty uuid.
+# Best-effort: a write failure is logged, never fatal. Args: <uuid>.
+save_discovery_uuid() {
+    local uuid="$1"
+    [ -n "$uuid" ] || return 0
+    printf '%s' "$uuid" > "${DATA_DIR}/discovery.uuid" 2>/dev/null \
+        || bashio::log.warning "Could not persist discovery uuid to ${DATA_DIR}/discovery.uuid."
+}
+
+# Remove a previously-published discovery message when a run has no radios to
+# advertise (e.g. the last/only dongle was unplugged), so Home Assistant stops
+# trying to reach a radio that is no longer present. All radios share a single
+# Supervisor discovery message (keyed by add-on + 'rtl_433' service), so there is
+# at most one uuid to delete, remembered in DATA_DIR by save_discovery_uuid.
+# Best-effort: any failure is logged and ignored. Needs SUPERVISOR_TOKEN; without
+# it (e.g. local/test runs) it is a no-op.
+remove_discovery_state() {
+    if [ -z "${SUPERVISOR_TOKEN:-}" ]
+    then
+        return 0
+    fi
+
+    local state="${DATA_DIR}/discovery.uuid" uuid http_code
+    [ -f "$state" ] || return 0
+    uuid="$(cat "$state" 2>/dev/null)"
+    if [ -z "$uuid" ]
+    then
+        rm -f "$state"
+        return 0
+    fi
+
+    http_code="$(curl -s -o /dev/null -w '%{http_code}' \
+        -X DELETE \
+        -H "Authorization: Bearer ${SUPERVISOR_TOKEN}" \
+        "http://supervisor/discovery/${uuid}" 2>/dev/null)" || http_code="000"
+
+    if [[ "$http_code" =~ ^2 ]]
+    then
+        bashio::log.info "Removed stale rtl_433 discovery message (uuid ${uuid}, HTTP ${http_code}); no radios are running."
+    else
+        # A 404 just means the message was already gone (e.g. the Supervisor
+        # purged it); either way the local state is cleared below.
+        bashio::log.warning "Removal of stale discovery uuid ${uuid} returned HTTP ${http_code} (non-fatal)."
+    fi
+    rm -f "$state"
+}
+
 # Run the add-on: read options, enumerate radios, launch rtl_433 per radio,
 # publish discovery, then block. Defined as a function so the file can be sourced
 # (e.g. by BATS tests) to load the pure helpers above without executing any of
@@ -505,7 +560,7 @@ main() {
                 # All radios share one Supervisor discovery message (equality is
                 # add-on + service, so each POST overwrites the same message and
                 # returns the same uuid); remember it for cleanup.
-                msg_uuid="$(printf '%s' "$resp_body" | sed -n 's/.*"uuid"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')"
+                msg_uuid="$(parse_discovery_uuid "$resp_body")"
                 [ -n "$msg_uuid" ] && published_uuid="$msg_uuid"
                 bashio::log.info "Published discovery for radio '${tag}' on port ${port} (HTTP ${http_code})."
             else
@@ -517,50 +572,8 @@ main() {
         done
 
         # Persist the discovery message uuid so a later boot with no radios can
-        # delete it (see remove_discovery_state). Best-effort: a write failure is
-        # logged but never fatal.
-        if [ -n "$published_uuid" ]
-        then
-            printf '%s' "$published_uuid" > "${DATA_DIR}/discovery.uuid" 2>/dev/null \
-                || bashio::log.warning "Could not persist discovery uuid to ${DATA_DIR}/discovery.uuid."
-        fi
-    }
-
-    # Remove a previously-published discovery message when this run has no radios
-    # to advertise (e.g. the last/only dongle was unplugged), so Home Assistant
-    # stops trying to reach a radio that is no longer present. All radios share a
-    # single Supervisor discovery message (keyed by add-on + 'rtl_433' service),
-    # so there is at most one uuid to delete, remembered in DATA_DIR by
-    # publish_discovery. Best-effort: any failure is logged and ignored.
-    remove_discovery_state() {
-        if [ -z "${SUPERVISOR_TOKEN:-}" ]
-        then
-            return 0
-        fi
-
-        local state="${DATA_DIR}/discovery.uuid" uuid http_code
-        [ -f "$state" ] || return 0
-        uuid="$(cat "$state" 2>/dev/null)"
-        if [ -z "$uuid" ]
-        then
-            rm -f "$state"
-            return 0
-        fi
-
-        http_code="$(curl -s -o /dev/null -w '%{http_code}' \
-            -X DELETE \
-            -H "Authorization: Bearer ${SUPERVISOR_TOKEN}" \
-            "http://supervisor/discovery/${uuid}" 2>/dev/null)" || http_code="000"
-
-        if [[ "$http_code" =~ ^2 ]]
-        then
-            bashio::log.info "Removed stale rtl_433 discovery message (uuid ${uuid}, HTTP ${http_code}); no radios are running."
-        else
-            # A 404 just means the message was already gone (e.g. the Supervisor
-            # purged it); either way the local state is cleared below.
-            bashio::log.warning "Removal of stale discovery uuid ${uuid} returned HTTP ${http_code} (non-fatal)."
-        fi
-        rm -f "$state"
+        # delete it (see remove_discovery_state).
+        save_discovery_uuid "$published_uuid"
     }
 
     # Advertise the running radios, or clean up a leftover discovery message when

--- a/tests/rtl_433/test_run.bats
+++ b/tests/rtl_433/test_run.bats
@@ -7,13 +7,15 @@
 #
 # run.sh has a main()-guard, so sourcing it under plain bash defines the helper
 # functions without executing the add-on body. These tests exercise the custom
-# logic: sysfs enumeration, serial usability, the unique-id fallback ladder, and
-# the raw match-id derivation. Uses only plain BATS assertions.
+# logic: sysfs enumeration, serial usability, the unique-id fallback ladder, the
+# raw match-id derivation, and the Supervisor discovery uuid persistence/cleanup.
+# Uses only plain BATS assertions.
 
 setup() {
     RUN_SH="${BATS_TEST_DIRNAME}/../../rtl_433/run.sh"
     # Source for function definitions only; the main-guard prevents the body
-    # from running. These helpers never call bashio, so no mock is needed.
+    # from running. The enumeration/identifier helpers never call bashio; the
+    # discovery tests stub bashio/curl themselves (see discovery_mocks).
     source "$RUN_SH"
 }
 
@@ -123,4 +125,101 @@ make_usb_dev() {
     run radio_match_id "00000000" "1-1.4"
     [ "$status" -eq 0 ]
     [ "$output" = "1-1.4" ]
+}
+
+# --- parse_discovery_uuid ----------------------------------------------------
+
+@test "parse_discovery_uuid extracts the uuid from a POST /discovery response" {
+    run parse_discovery_uuid '{"result":"ok","data":{"uuid":"abc123DEF456"}}'
+    [ "$status" -eq 0 ]
+    [ "$output" = "abc123DEF456" ]
+}
+
+@test "parse_discovery_uuid emits nothing when the body carries no uuid" {
+    run parse_discovery_uuid '{"result":"error","message":"bad service"}'
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+# --- save_discovery_uuid / remove_discovery_state ----------------------------
+
+# Stub the Supervisor-facing dependencies: bashio logging is silenced and curl
+# records its arguments to $CURL_LOG and prints $MOCK_HTTP_CODE (mimicking
+# 'curl -w %{http_code}' with the response body discarded via -o /dev/null). The
+# stubs and variables are inherited by the subshell that 'run' forks. DATA_DIR is
+# pointed at a per-test temp dir; the discovery helpers read it at call time.
+discovery_mocks() {
+    DATA_DIR="$BATS_TEST_TMPDIR/data"
+    mkdir -p "$DATA_DIR"
+    CURL_LOG="$BATS_TEST_TMPDIR/curl.log"
+    : > "$CURL_LOG"
+    MOCK_HTTP_CODE="200"
+    bashio::log.info()    { :; }
+    bashio::log.warning() { :; }
+    curl() { printf '%s\n' "$*" >> "$CURL_LOG"; printf '%s' "$MOCK_HTTP_CODE"; }
+}
+
+@test "save_discovery_uuid writes the uuid under DATA_DIR" {
+    discovery_mocks
+    run save_discovery_uuid "uuid-xyz"
+    [ "$status" -eq 0 ]
+    [ "$(cat "$DATA_DIR/discovery.uuid")" = "uuid-xyz" ]
+}
+
+@test "save_discovery_uuid is a no-op for an empty uuid" {
+    discovery_mocks
+    run save_discovery_uuid ""
+    [ "$status" -eq 0 ]
+    [ ! -e "$DATA_DIR/discovery.uuid" ]
+}
+
+@test "save+remove round-trip: persisted uuid is DELETEd and the state cleared" {
+    SUPERVISOR_TOKEN="tok"
+    discovery_mocks
+    save_discovery_uuid "uuid-123"
+    MOCK_HTTP_CODE="200"
+    run remove_discovery_state
+    [ "$status" -eq 0 ]
+    grep -q -- "-X DELETE" "$CURL_LOG"
+    grep -q "http://supervisor/discovery/uuid-123" "$CURL_LOG"
+    [ ! -e "$DATA_DIR/discovery.uuid" ]
+}
+
+@test "remove_discovery_state clears local state even on a non-2xx (already gone)" {
+    SUPERVISOR_TOKEN="tok"
+    discovery_mocks
+    save_discovery_uuid "uuid-404"
+    MOCK_HTTP_CODE="404"
+    run remove_discovery_state
+    [ "$status" -eq 0 ]
+    grep -q "http://supervisor/discovery/uuid-404" "$CURL_LOG"
+    [ ! -e "$DATA_DIR/discovery.uuid" ]
+}
+
+@test "remove_discovery_state is a no-op when no state file exists" {
+    SUPERVISOR_TOKEN="tok"
+    discovery_mocks
+    run remove_discovery_state
+    [ "$status" -eq 0 ]
+    [ ! -s "$CURL_LOG" ]   # curl never called
+}
+
+@test "remove_discovery_state clears an empty state file without calling curl" {
+    SUPERVISOR_TOKEN="tok"
+    discovery_mocks
+    : > "$DATA_DIR/discovery.uuid"
+    run remove_discovery_state
+    [ "$status" -eq 0 ]
+    [ ! -s "$CURL_LOG" ]
+    [ ! -e "$DATA_DIR/discovery.uuid" ]
+}
+
+@test "remove_discovery_state skips entirely without a Supervisor token" {
+    unset SUPERVISOR_TOKEN
+    discovery_mocks
+    save_discovery_uuid "uuid-x"
+    run remove_discovery_state
+    [ "$status" -eq 0 ]
+    [ ! -s "$CURL_LOG" ]                   # curl never called
+    [ -e "$DATA_DIR/discovery.uuid" ]      # state left untouched
 }


### PR DESCRIPTION
## What

When the add-on starts with **no radios** to advertise (e.g. the last/only RTL-SDR dongle was unplugged), it now deletes the Supervisor discovery message it previously published, so Home Assistant stops trying to reach a radio that no longer exists.

## Supervisor discovery semantics (verified against the Supervisor source)

- **One stored message per `(add-on, service)`.** The discovery `Message`'s `config` has been `eq=False` since 2019 (PRs #974/#1329), so message equality is `app + service` only, and `send()` `break`s on the first match — it **cannot store more than one message** for our `rtl_433` service. Each per-radio POST overwrites that single message's config in place and returns the **same uuid**.
- **Add-ons can't list discovery** (`GET /discovery` is `@require_home_assistant`), but **can `DELETE` their own message by uuid** (ownership-checked), and the uuid comes back in the POST response.

### Why you still see one "Discovered" entry per radio

Each POST also *pushes* to Home Assistant (`CMD_NEW`), and the integration's `async_step_hassio` sets a distinct per-radio `unique_id`. HA's flow manager keys in-progress discovery flows by that id, so HA holds **one "Discovered" flow per radio** — even though those pushes all rode through the single overwritten Supervisor message. So the per-radio entries you see in *Settings → Devices & Services → Discovered* live a layer above the Supervisor's discovery store, which holds exactly one message.

## What this changes

- `publish_discovery` captures the uuid from the POST response and persists it to the add-on's `/data` volume (`/data/discovery.uuid`). All radios share one message → one uuid.
- New `remove_discovery_state`: on a boot with **no radios**, `DELETE`s that uuid and clears the state file. A `404` (already gone) is treated as success.
- Re-publishing with ≥1 radio keeps the single message current, so this only fires in the zero-radio case. Everything is best-effort and never blocks the radios.

### Behavioural notes / limitations

- **Remove the last/only radio → reboot the add-on:** the message is deleted, the Supervisor fires `CMD_DEL`, and the stale "Discovered" flow disappears. ✅ This is the case this PR fixes.
- **Remove one of several radios → reboot the add-on:** the remaining radios are still advertised, so the single message stays live and is *not* deleted. The removed radio's "Discovered" flow isn't proactively removed; it self-heals on the next **HA Core restart** (in-progress flows are rebuilt only from what's currently advertised). Proactive per-radio removal would require one Supervisor message *per radio* (distinct declared `service` names), which isn't workable with a dynamic radio count.

**Out of scope (per design):** removing Home Assistant *config entries* for radios that went away — those persist until the user removes them.

## Refactor + tests (included here; squash-friendly commits)

The cleanup logic was originally nested inside `main()`, so the BATS suite (which sources `run.sh` behind its `main()`-guard) couldn't reach it. This PR lifts three side-effect-isolated helpers to top-level with **no behaviour change** — `parse_discovery_uuid`, `save_discovery_uuid`, `remove_discovery_state` — and adds coverage:

- uuid extraction (present / absent)
- persistence (writes under `DATA_DIR` / empty no-op)
- save→remove round-trip asserts the actual `DELETE /discovery/<uuid>` and that state is cleared
- non-2xx (already gone) still clears local state
- no-op when no state file exists
- empty state file cleared without calling curl
- skips entirely without `SUPERVISOR_TOKEN`, leaving state untouched

`curl` and `bashio` logging are stubbed locally (the curl stub records its args and returns a configurable HTTP status); `DATA_DIR` points at a per-test temp dir.

## Implementation note

The prior "jq is not in the runtime image" comment was inaccurate (bashio depends on jq), but the small fixed-shape response is parsed with `sed` to match how the existing code already reads Supervisor JSON.

## Testing

- `bats -r tests/` → 20/20 pass (11 existing + 9 new)
- `shellcheck` clean on `run.sh` and the `.bats` file
- `pre-commit run --files …` → all hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)