### PR TITLE
ci: use a stable cache tag to skip the 65s cosign verify retry on releases

### DIFF
--- a/.github/workflows/build-addon.yml
+++ b/.github/workflows/build-addon.yml
@@ -147,7 +147,17 @@ jobs:
       with:
         arch: ${{ matrix.arch }}
         image: ${{ env.REGISTRY_PREFIX }}/${{ matrix.arch }}-${{ matrix.addon }}
-        image-tags: ${{ steps.version.outputs.version }}
+        # Push the version tag plus a stable "cache" tag. build-image verifies
+        # the Cosign signature on cache-image-tag *before* the build to decide
+        # whether it can reuse that image as a registry build cache. Pointing it
+        # at the per-build version tag means the tag never exists yet, so the
+        # verify burns ~65s in retry backoff every release. A stable "cache" tag
+        # (re-pushed and signed each build) verifies in ~1s and is reused as
+        # build cache. These are internal per-arch images; users pull the
+        # multi-arch manifest, never the "cache" tag.
+        image-tags: |
+          ${{ steps.version.outputs.version }}
+          cache
         version: ${{ steps.version.outputs.version }}
         context: ${{ matrix.addon }}
         build-args: ${{ steps.buildconf.outputs.build_args }}
@@ -156,7 +166,7 @@ jobs:
         push: ${{ inputs.build-type != 'test' }}
         cosign: ${{ inputs.build-type != 'test' }}
         cache-gha-scope: ${{ matrix.addon }}
-        cache-image-tag: ${{ steps.version.outputs.version }}
+        cache-image-tag: cache
 
   # Combine the per-arch images into a single multi-arch manifest per addon and
   # sign it with Cosign. Skipped for "test" builds, which never push images.


### PR DESCRIPTION
## Problem

On every release, `home-assistant/builder/actions/build-image` spends **~65s** in a Cosign retry loop before the build even starts, emitting:

> `Image verification failed for ghcr.io/rtl-433-hass/<arch>-rtl_433:<version>, ignoring`

The build itself succeeds — images are pushed and signed — but the wasted minute sits on the release critical path (per arch, in parallel).

## Cause

`build-image` runs a `cosign-verify` step on `${image}:${cache-image-tag}` *before* the build, to decide whether that image can be reused as a registry build cache. We pointed `cache-image-tag` at the **per-build version tag** (e.g. `0.4.0`). That tag is exactly what this run is about to create, so it never exists beforehand → `MANIFEST_UNKNOWN` → 5 retries with exponential backoff (~2/4/8/16/32s) → `allow-failure` warning. Side effect: the registry build cache was never actually reused.

## Fix

Push a stable **`cache`** tag alongside the version tag and verify against it:

- First build after merge: ~65s once (the `cache` tag doesn't exist yet per per-arch image).
- Every release after: verify succeeds in ~1s, and the prior image is reused as a registry build cache.

Cosign signs by digest, and both `<version>` and `cache` resolve to the same digest, so signing/verification cover both. PR/test builds are unaffected (`push:false`/`cosign:false` skips the verify step). The only visible change is a `cache` tag on the internal per-arch images (`ghcr.io/rtl-433-hass/<arch>-rtl_433:cache`), which users never pull directly — they consume the multi-arch `rtl_433` manifest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)