### PR TITLE
feat(rtl_433): make the noise-floor scan duration configurable

### DIFF
--- a/rtl_433-next/config.json
+++ b/rtl_433-next/config.json
@@ -19,7 +19,8 @@
     "log_diagnostic_messages": false,
     "correct_ppm_offset": false,
     "detect_noise_floor": false,
-    "noise_floor_bands": "433.92M,868M,915M"
+    "noise_floor_bands": "433.92M,868M,915M",
+    "noise_floor_duration": 30
   },
   "schema": {
     "disable_tpms": "bool",
@@ -27,7 +28,8 @@
     "log_diagnostic_messages": "bool",
     "correct_ppm_offset": "bool",
     "detect_noise_floor": "bool",
-    "noise_floor_bands": "str"
+    "noise_floor_bands": "str",
+    "noise_floor_duration": "int(1,600)"
   },
   "ports": {
     "8433/tcp": 8433,

--- a/rtl_433/README.md
+++ b/rtl_433/README.md
@@ -111,13 +111,15 @@ Notes:
 
 The **Detect noise floor** option (off by default) measures the ambient RF noise level around the bands your sensors use, which is useful for diagnosing reception problems (a high noise floor means weak signals are harder to decode). The companion **Noise floor bands** option is a comma-separated list of center frequencies to sweep; it defaults to `433.92M,868M,915M` (the common ISM bands). Each entry may be written in MHz with an `M` suffix (`433.92M`, `868M`) or as a plain integer number of hertz (`915000000`).
 
+The **Noise floor duration** option sets how many seconds each band is sampled (default `30`, range `1`–`600`). Each band is swept in 1-second passes for this long, and the min/median/peak are taken across every sweep — so a longer duration captures **time-varying (intermittent) interference** rather than a single instant. A short value (e.g. `1`) gives a quick instantaneous snapshot of the static floor; the `30`-second default trades startup time for a measurement that better reflects bursty interferers.
+
 While the option is on, every radio is swept with `rtl_power` **on every boot** — so turn it back off once you have collected the reports you need. Each scan writes a set of **timestamped** files into the add-on config directory (reachable at `/addon_configs/rtl433/`):
 
  - `noise-<id>-<timestamp>.csv` — the raw `rtl_power` sweeps.
  - `noise-<id>-<timestamp>.txt` — a per-band min / median / peak summary in dBm.
  - `noise-<id>-<timestamp>.png` — a spectrum graph.
 
-The `<id>` is the radio's identifier (the same one used for override files). Because the files are timestamped, each boot produces a new set; **the add-on never deletes old reports**, so clean them up yourself when you no longer need them. A one-line per-band summary is also written to the add-on log. Unlike the parallel PPM measurement above, **radios are scanned one after another, and startup is paused for each** — but each band is only a quick ~1-second `rtl_power` snapshot (bounded by a 30-second safety timeout), so in practice this adds just a few seconds per radio.
+The `<id>` is the radio's identifier (the same one used for override files). Because the files are timestamped, each boot produces a new set; **the add-on never deletes old reports**, so clean them up yourself when you no longer need them. A one-line per-band summary is also written to the add-on log. Unlike the parallel PPM measurement above, **radios are scanned one after another, and startup is paused for each** — so the added startup per radio is roughly **Noise floor duration × the number of bands** (plus a little device setup). With the defaults (30 seconds × 3 bands) that's about **90 seconds per radio**; lower **Noise floor duration** for a quicker scan or raise it for a more thorough interference survey.
 
 **Important:** the noise floor reported here is a **boot-time snapshot taken at the configured band(s)**, not at whatever frequency Home Assistant is using at runtime. The rtl_433 integration can retune a radio after boot, so the live operating frequency may differ from the band(s) measured here. Treat the report as a point-in-time survey of the configured bands, not a continuous measurement of the radio's current frequency.
 

--- a/rtl_433/config.json
+++ b/rtl_433/config.json
@@ -25,7 +25,8 @@
     "log_diagnostic_messages": false,
     "correct_ppm_offset": false,
     "detect_noise_floor": false,
-    "noise_floor_bands": "433.92M,868M,915M"
+    "noise_floor_bands": "433.92M,868M,915M",
+    "noise_floor_duration": 30
   },
   "schema": {
     "disable_tpms": "bool",
@@ -33,7 +34,8 @@
     "log_diagnostic_messages": "bool",
     "correct_ppm_offset": "bool",
     "detect_noise_floor": "bool",
-    "noise_floor_bands": "str"
+    "noise_floor_bands": "str",
+    "noise_floor_duration": "int(1,600)"
   },
   "ports": {
     "8433/tcp": 8433,

--- a/rtl_433/run.sh
+++ b/rtl_433/run.sh
@@ -492,6 +492,17 @@ main() {
         noise_floor_bands="433.92M,868M,915M"
     fi
 
+    # Seconds rtl_power samples each band when detect_noise_floor is on. A longer
+    # window accumulates more sweeps so the min/median/peak reflect time-varying
+    # (intermittent) interference rather than a single instant. Each band is swept
+    # serially per radio, so the per-radio cost is roughly this times the number
+    # of bands. Falls back to the default when unset/non-numeric/out of range.
+    noise_floor_duration="$(bashio::config 'noise_floor_duration')"
+    if ! [[ "$noise_floor_duration" =~ ^[0-9]+$ ]] || [ "$noise_floor_duration" -lt 1 ] || [ "$noise_floor_duration" -gt 600 ]
+    then
+        noise_floor_duration=30
+    fi
+
     # Directory rendered configs are written to. Never the user config directory.
     mkdir -p "$render_dir"
 
@@ -706,13 +717,16 @@ main() {
             return 0
         fi
 
-        bashio::log.info "Radio ${id}: measuring noise floor over ${#bands[@]} band(s) (startup paused briefly)..."
+        bashio::log.info "Radio ${id}: measuring noise floor over ${#bands[@]} band(s) at ${noise_floor_duration}s each (startup paused)..."
         for lo_hi_bin in "${bands[@]}"
         do
             tmp="$(mktemp 2>/dev/null)" || continue
-            # One-shot sweep; 'timeout' bounds a hung rtl_power. A non-zero exit or
-            # empty capture is tolerated (the radio must still launch).
-            if ! timeout 30 rtl_power -d "$sel" -f "$lo_hi_bin" -i 1 -1 "$tmp" >/dev/null 2>&1
+            # Sample the band for noise_floor_duration seconds in 1-second sweeps so
+            # the accumulated rows capture time-varying interference (not a single
+            # instant). 'timeout' bounds a hung rtl_power with a margin for device
+            # setup/teardown. A non-zero exit or empty capture is tolerated (the
+            # radio must still launch).
+            if ! timeout "$((noise_floor_duration + 15))" rtl_power -d "$sel" -f "$lo_hi_bin" -i 1 -e "$noise_floor_duration" "$tmp" >/dev/null 2>&1
             then
                 bashio::log.warning "Radio ${id}: rtl_power sweep of ${lo_hi_bin} failed (non-fatal)."
             fi

--- a/tests/config/validate_configs.py
+++ b/tests/config/validate_configs.py
@@ -29,6 +29,7 @@ RADIO_OPT_OPTIONS = {
     "correct_ppm_offset": (False, "bool"),
     "detect_noise_floor": (False, "bool"),
     "noise_floor_bands": ("433.92M,868M,915M", "str"),
+    "noise_floor_duration": (30, "int(1,600)"),
 }
 
 


### PR DESCRIPTION
> Stacked on #79 (base branch is `perf/parallel-ppm-measurement`). Review/merge #79 first, or retarget to `main` once #79 lands.

## Problem

The noise-floor scan took a **single ~1-second one-shot `rtl_power` sweep per band**, so its min/median/peak described a single instant. Intermittent/bursty interference (the most useful thing to catch) could be missed entirely or over-weighted in the peak.

## Change

Add a **`noise_floor_duration`** option — seconds sampled per band, default **30**, range **1–600**:

- Each band is now swept in 1-second passes for `noise_floor_duration` seconds via `rtl_power -i 1 -e <duration>` (was `-i 1 -1`), and the stats aggregate across **every** sweep, so they reflect time-varying interference.
- The per-band `timeout` now tracks the duration (`duration + 15s` for device setup/teardown) instead of a flat 30s.
- `noise_floor_duration: 1` reproduces the old quick snapshot.

Added to both `rtl_433` and `rtl_433-next` `config.json` (options + `int(1,600)` schema) and read/validated in `run.sh` (falls back to 30 on a missing/non-numeric/out-of-range value).

## Startup cost

Per radio ≈ **duration × number of bands** (serial). Defaults (30s × 3 bands) ≈ **90 s/radio**. The README documents this and how to tune it down/up.

## Why this stays serial (not parallelized like PPM)

Unlike PPM, multiple dongles tuned at once can leak each other's local-oscillator spurs into the measured spectrum, skewing absolute noise readings — so the sweeps remain one-at-a-time.

## Testing

- `python3 tests/config/validate_configs.py` — both add-ons pass (validator now requires the new option).
- `bats -r tests/` — all 35 pass.
- `pre-commit run --files …` — shellcheck / check-json / formatting pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)