### PR TITLE
docs: add Changelog title so release-please orders entries correctly

### DIFF
--- a/rtl_433/CHANGELOG.md
+++ b/rtl_433/CHANGELOG.md
@@ -1,11 +1,4 @@
-## [0.4.0](https://github.com/rtl-433-hass/rtl_433-hass-addons/compare/v0.3.0...v0.4.0) (2026-06-02)
-
-
-### Features
-
-* **rtl_433:** add SDR optimization tooling and add-on options ([8b89912](https://github.com/rtl-433-hass/rtl_433-hass-addons/commit/8b89912df4836d1024646a8adb1cb364f9183446))
-* **rtl_433:** auto-correct PPM offset on startup ([fcf0974](https://github.com/rtl-433-hass/rtl_433-hass-addons/commit/fcf09749593ae6867028fcf385e345f6c0a7d352))
-* **rtl_433:** detect noise floor on startup with rtl_power ([8e74976](https://github.com/rtl-433-hass/rtl_433-hass-addons/commit/8e7497641e36a68088e9ce72c2f1a640c8c15d53))
+# Changelog
 
 ## [0.5.0](https://github.com/rtl-433-hass/rtl_433-hass-addons/compare/v0.4.0...v0.5.0) (2026-06-03)
 
@@ -18,6 +11,15 @@
 ### Performance Improvements
 
 * **rtl_433:** measure radio PPM offsets in parallel at startup ([1977d69](https://github.com/rtl-433-hass/rtl_433-hass-addons/commit/1977d69cecc561b33d773af64d69dc63037bee39))
+
+## [0.4.0](https://github.com/rtl-433-hass/rtl_433-hass-addons/compare/v0.3.0...v0.4.0) (2026-06-02)
+
+
+### Features
+
+* **rtl_433:** add SDR optimization tooling and add-on options ([8b89912](https://github.com/rtl-433-hass/rtl_433-hass-addons/commit/8b89912df4836d1024646a8adb1cb364f9183446))
+* **rtl_433:** auto-correct PPM offset on startup ([fcf0974](https://github.com/rtl-433-hass/rtl_433-hass-addons/commit/fcf09749593ae6867028fcf385e345f6c0a7d352))
+* **rtl_433:** detect noise floor on startup with rtl_power ([8e74976](https://github.com/rtl-433-hass/rtl_433-hass-addons/commit/8e7497641e36a68088e9ce72c2f1a640c8c15d53))
 
 ## [0.3.0](https://github.com/rtl-433-hass/rtl_433-hass-addons/compare/v0.2.0...v0.3.0) (2026-06-01)
 


### PR DESCRIPTION
## Problem

release-please generates changelog entries in the wrong order. The 0.4.0 notes landed *below* 0.3.0 (hand-fixed in `73dd1b7`), and the bug then recurred — `release 0.5.0` (#eaf2a7f) landed *below* 0.4.0.

## Root cause

release-please's changelog updater finds its insertion point with the regex `\n###? v?[0-9[]`, which requires a **newline immediately before** a version header. `rtl_433/CHANGELOG.md` started directly with `## [version]…` at byte 0, so the topmost entry had no preceding newline and was invisible to the regex. The first *match* was the **second** entry, and release-please inserts a new release *before the first match* — landing it below the current top entry.

This was introduced when the changelog was reset in #74, which dropped the leading title. release-please only emits its own `# Changelog` header when it can't find an existing entry to anchor to, so once a title-less file slipped through, every later release inherited the bug.

## Fix

- Add the canonical `# Changelog` H1 title. The first version header now has a preceding newline, the regex anchors on it, and each new release is inserted at the very top in correct descending order.
- Reorder the already-misplaced 0.5.0 entry above 0.4.0.

Final order: 0.5.0 → 0.4.0 → 0.3.0 → 0.2.0 → 0.1.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)