### PR TITLE
feat(rtl_433): emit signal level data (-M level) in decoded events

### DIFF
--- a/rtl_433/README.md
+++ b/rtl_433/README.md
@@ -143,6 +143,17 @@ Two independent options in the add-on's Configuration tab control what rtl_433 w
 
 Both default to off and can be enabled independently.
 
+### Signal level data
+
+The baked-in default config enables rtl_433's **level reporting**
+(`report_meta level`, the config-file equivalent of the `-M level` CLI flag), so
+every decoded message carries the radio's per-transmission **frequency**,
+**RSSI**, **SNR**, and **noise**. The
+[rtl_433 integration for Home Assistant](https://github.com/rtl-433-hass/rtl_433)
+surfaces these as optional per-device diagnostic sensors (disabled by default —
+enable the ones you want from each device page) for charting signal strength and
+reception quality. No add-on configuration is required.
+
 ### Breaking change / migration
 
 Earlier versions of this add-on read config files from `/config/rtl_433/` in the **Home Assistant config directory**. That location is **no longer read**. Move any per-radio tuning into `<id>.conf` files in the **add-on config directory** (`/addon_configs/rtl433/`) as described above. There is no longer a separate config file for the default case — the default is baked into the image.

--- a/rtl_433/rtl_433.defaults.conf
+++ b/rtl_433/rtl_433.defaults.conf
@@ -7,7 +7,11 @@
 # assigned HTTP port. The add-on injects the correct 'device' line per radio.
 
 output http://0.0.0.0:{{port}}
-report_meta time:iso:usec:tz
+# 'level' (the config-file equivalent of the '-M level' CLI flag) adds the
+# per-event radio level data — frequency, RSSI, SNR, and noise — to each decoded
+# message, which the rtl_433 Home Assistant integration surfaces as optional
+# diagnostic sensors.
+report_meta time:iso:usec:tz level
 
 # The "Log received messages" add-on option appends 'output kv' to log decoded
 # events to the add-on log.


### PR DESCRIPTION
## Summary

Enables rtl_433's **level reporting** in the add-on's baked-in default config so every decoded message includes per-transmission radio level data — **frequency, RSSI, SNR, and noise**.

This is done by adding `level` to the `report_meta` directive in `rtl_433/rtl_433.defaults.conf` (the config-file equivalent of the `-M level` CLI flag). No add-on options change; it works with no configuration.

The companion [rtl_433 Home Assistant integration](https://github.com/rtl-433-hass/rtl_433) consumes these fields and exposes them as optional per-device diagnostic sensors (disabled by default). See its companion PR.

## Changes

- `rtl_433/rtl_433.defaults.conf` — append `level` to `report_meta`, with an explanatory comment.
- `rtl_433/README.md` — new **Signal level data** subsection documenting the output.

## Testing

- `bats -r tests/` — all 35 pass.
- `python3 tests/config/validate_configs.py` — both `rtl_433` and `rtl_433-next` pass.
- `pre-commit run --files …` on the changed files — pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)