### PR TITLE
fix(rtl_433): show only the new version's notes in the add-on update dialog

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -55,10 +55,12 @@ jobs:
       #
       # Rewrite the headings on the release PR branch so the fix ships as part
       # of the release commit. The date and compare link are preserved on the
-      # line below each heading. The sed only matches release-please's bracketed
+      # line below each heading. Rather than adding a second commit, the rewrite
+      # is amended into release-please's own commit and force-pushed, so the PR
+      # stays a single commit. The sed only matches release-please's bracketed
       # form, so it is idempotent: re-running on an already-normalized file (the
       # usual case, since release-please regenerates the branch on every push)
-      # changes nothing and the step exits without an empty commit.
+      # changes nothing and the step exits without amending or pushing.
       #
       # Pushes use the App token in the clone URL, not GITHUB_TOKEN, so the
       # workflow's `permissions: {}` posture is unchanged.
@@ -79,7 +81,9 @@ jobs:
             echo "CHANGELOG headings already Home Assistant-compatible; nothing to do."
             exit 0
           fi
+          # Amend into release-please's commit (preserving its message and
+          # author) so the PR keeps a single commit, then force-push the branch.
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git commit -am "docs: format changelog headings for Home Assistant update notes"
-          git push origin "HEAD:${PR_BRANCH}"
+          git commit --amend --no-edit -a
+          git push --force-with-lease origin "HEAD:${PR_BRANCH}"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -44,3 +44,42 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+      # release-please writes version headings as "## [x.y.z](compare) (date)".
+      # Home Assistant's Supervisor, however, only trims the add-on update
+      # dialog to the version you're updating *to* when each heading is a bare
+      # "## x.y.z" -- it slices CHANGELOG.md with the regex `^#* <version>\n`
+      # (homeassistant/components/hassio/update.py: async_release_notes). With
+      # the bracketed form the regex never matches and the dialog shows the
+      # ENTIRE changelog on every update.
+      #
+      # Rewrite the headings on the release PR branch so the fix ships as part
+      # of the release commit. The date and compare link are preserved on the
+      # line below each heading. The sed only matches release-please's bracketed
+      # form, so it is idempotent: re-running on an already-normalized file (the
+      # usual case, since release-please regenerates the branch on every push)
+      # changes nothing and the step exits without an empty commit.
+      #
+      # Pushes use the App token in the clone URL, not GITHUB_TOKEN, so the
+      # workflow's `permissions: {}` posture is unchanged.
+      - name: Normalize CHANGELOG headings for Home Assistant
+        if: ${{ steps.release.outputs.pr }}
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_BRANCH: ${{ fromJSON(steps.release.outputs.pr).headBranchName }}
+        run: |
+          set -euo pipefail
+          git clone --branch "$PR_BRANCH" --depth 1 \
+            "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" rp-branch
+          cd rp-branch
+          sed -i -E \
+            's@^(#{2,}) \[([^]]+)\]\(([^)]+)\) \(([0-9]{4}-[0-9]{2}-[0-9]{2})\)$@\1 \2\n\n_\4_ · [Compare](\3)@' \
+            rtl_433/CHANGELOG.md
+          if git diff --quiet; then
+            echo "CHANGELOG headings already Home Assistant-compatible; nothing to do."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -am "docs: format changelog headings for Home Assistant update notes"
+          git push origin "HEAD:${PR_BRANCH}"

--- a/rtl_433/CHANGELOG.md
+++ b/rtl_433/CHANGELOG.md
@@ -1,13 +1,17 @@
 # Changelog
 
-## [0.6.0](https://github.com/rtl-433-hass/rtl_433-hass-addons/compare/v0.5.0...v0.6.0) (2026-06-03)
+## 0.6.0
+
+_2026-06-03_ · [Compare](https://github.com/rtl-433-hass/rtl_433-hass-addons/compare/v0.5.0...v0.6.0)
 
 
 ### Features
 
 * **rtl_433:** emit signal level data (-M level) in decoded events ([efac922](https://github.com/rtl-433-hass/rtl_433-hass-addons/commit/efac9227b00604409262210ccfd1afd58ad41d15))
 
-## [0.5.0](https://github.com/rtl-433-hass/rtl_433-hass-addons/compare/v0.4.0...v0.5.0) (2026-06-03)
+## 0.5.0
+
+_2026-06-03_ · [Compare](https://github.com/rtl-433-hass/rtl_433-hass-addons/compare/v0.4.0...v0.5.0)
 
 
 ### Features
@@ -19,7 +23,9 @@
 
 * **rtl_433:** measure radio PPM offsets in parallel at startup ([1977d69](https://github.com/rtl-433-hass/rtl_433-hass-addons/commit/1977d69cecc561b33d773af64d69dc63037bee39))
 
-## [0.4.0](https://github.com/rtl-433-hass/rtl_433-hass-addons/compare/v0.3.0...v0.4.0) (2026-06-02)
+## 0.4.0
+
+_2026-06-02_ · [Compare](https://github.com/rtl-433-hass/rtl_433-hass-addons/compare/v0.3.0...v0.4.0)
 
 
 ### Features
@@ -28,7 +34,9 @@
 * **rtl_433:** auto-correct PPM offset on startup ([fcf0974](https://github.com/rtl-433-hass/rtl_433-hass-addons/commit/fcf09749593ae6867028fcf385e345f6c0a7d352))
 * **rtl_433:** detect noise floor on startup with rtl_power ([8e74976](https://github.com/rtl-433-hass/rtl_433-hass-addons/commit/8e7497641e36a68088e9ce72c2f1a640c8c15d53))
 
-## [0.3.0](https://github.com/rtl-433-hass/rtl_433-hass-addons/compare/v0.2.0...v0.3.0) (2026-06-01)
+## 0.3.0
+
+_2026-06-01_ · [Compare](https://github.com/rtl-433-hass/rtl_433-hass-addons/compare/v0.2.0...v0.3.0)
 
 
 ### Features
@@ -41,7 +49,9 @@
 
 * **rtl_433:** supervise each radio so one failure doesn't stop the add-on ([554cc81](https://github.com/rtl-433-hass/rtl_433-hass-addons/commit/554cc81c40701bc51aac1e78302f73b7508e8043))
 
-## [0.2.0](https://github.com/rtl-433-hass/rtl_433-hass-addons/compare/v0.1.0...v0.2.0) (2026-06-01)
+## 0.2.0
+
+_2026-06-01_ · [Compare](https://github.com/rtl-433-hass/rtl_433-hass-addons/compare/v0.1.0...v0.2.0)
 
 
 ### ⚠ BREAKING CHANGES
@@ -61,7 +71,9 @@
 * **rtl_433:** store config in the add-on config dir and add log option ([05bcfb9](https://github.com/rtl-433-hass/rtl_433-hass-addons/commit/05bcfb9dd51f621ad4319ac9feaa2899a3d8d08e))
 * **rtl_433:** support manually-declared SoapySDR/HackRF radios ([9507a2d](https://github.com/rtl-433-hass/rtl_433-hass-addons/commit/9507a2d6495637f68e82e65ce607f8c8b8b0b73f))
 
-## [0.1.0](https://github.com/rtl-433-hass/rtl_433-hass-addons/compare/v0.0.1...v0.1.0) (2026-05-30)
+## 0.1.0
+
+_2026-05-30_ · [Compare](https://github.com/rtl-433-hass/rtl_433-hass-addons/compare/v0.0.1...v0.1.0)
 
 
 ### ⚠ BREAKING CHANGES


### PR DESCRIPTION
## Problem

When updating the **rtl_433 add-on**, Home Assistant's update dialog shows the release notes for **every past release**, not just the version being installed. The **HACS integration** does not have this problem — it only shows the latest release.

## Root cause

The two repos have structurally identical, release-please-generated changelogs, so the difference isn't the changelog content — it's *how each is surfaced*:

| | Source of release notes | Result |
|---|---|---|
| Integration (HACS) | GitHub **Release body** (already one version) | ✅ shows only latest |
| Add-on (Supervisor) | **CHANGELOG.md**, sliced by HA core | ❌ shows everything |

HA core's add-on update entity slices `CHANGELOG.md` with this regex (`homeassistant/components/hassio/update.py` → `async_release_notes`):

```python
regex_pattern = re.compile(
    rf"^#* {re.escape(self.latest_version)}\n"
    rf"(?:^(?!#* {re.escape(self.installed_version)}).*\n)*",
    re.MULTILINE,
)
```

It only matches a **bare** heading — `## 0.6.0` immediately followed by a newline. release-please writes:

```
## [0.6.0](https://github.com/.../compare/v0.5.0...v0.6.0) (2026-06-03)
```

The `[`, link, and date mean the regex never matches, so HA falls back to `return changelog` — the **entire** file. Official HA add-ons (e.g. `core-mosquitto`) use bare `## x.y.z` headings, which is why their dialogs trim correctly.

## Fix

1. **Backfill** — rewrite existing version headings to the bare `## x.y.z` form HA expects, preserving the date + compare link on the line below:
   ```
   ## 0.6.0

   _2026-06-03_ · [Compare](https://github.com/.../compare/v0.5.0...v0.6.0)
   ```
2. **Keep it that way** — a `release-please.yml` post-step applies the same **idempotent** rewrite to the release PR branch on each run (release-please has no native option for the heading format). The push uses the App token, so the workflow's `permissions: {}` posture is unchanged.

## Verification

Ran HA core's exact regex against the transformed file:

- **Before:** returns the full changelog (5815 of 5815 chars) — the bug.
- **After (0.5.0 → 0.6.0):** returns only the `## 0.6.0` section, stopping before `## 0.5.0`.
- **After (multi-version jump 0.2.0 → 0.6.0):** returns `0.6.0`, `0.5.0`, `0.4.0`, `0.3.0` and stops before `0.2.0` — i.e. everything since the installed version, as intended.
- The `sed` transform is idempotent (running it twice == once), and `actionlint` / `check-yaml` / `end-of-file-fixer` / `trailing-whitespace` all pass.

## Draft because

The workflow post-step pushes to the release PR branch and can only be exercised by a real release run on `main`. The backfill and regex behavior are verified locally; the CI step's live behavior should be confirmed on the next release (or by a maintainer comfortable with the App-token push). Happy to adjust — e.g. drop the date/compare sub-line for the plainer official-add-on style if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)