### PR TITLE
fix(rtl_433): emit report_meta level on its own line so level data is kept

### DIFF
--- a/rtl_433/rtl_433.defaults.conf
+++ b/rtl_433/rtl_433.defaults.conf
@@ -10,8 +10,11 @@ output http://0.0.0.0:{{port}}
 # 'level' (the config-file equivalent of the '-M level' CLI flag) adds the
 # per-event radio level data — frequency, RSSI, SNR, and noise — to each decoded
 # message, which the rtl_433 Home Assistant integration surfaces as optional
-# diagnostic sensors.
-report_meta time:iso:usec:tz level
+# diagnostic sensors. It MUST be on its own 'report_meta' line: rtl_433 only
+# colon-combines sub-options within a single meta type, so a second type on the
+# same line (e.g. 'time:... level') is silently dropped — keeping only 'time'.
+report_meta time:iso:usec:tz
+report_meta level
 
 # The "Log received messages" add-on option appends 'output kv' to log decoded
 # events to the add-on log.

--- a/tests/rtl_433/test_run.bats
+++ b/tests/rtl_433/test_run.bats
@@ -363,3 +363,24 @@ ppm_cache_mocks() {
     [ "$status" -ne 0 ]
     [ -z "$output" ]
 }
+
+# --- baked-in default config: report_meta -----------------------------------
+
+# rtl_433 only colon-combines sub-options within a single meta type, so 'level'
+# must sit on its own 'report_meta' line; combining it with 'time' (e.g.
+# 'report_meta time:... level') silently drops the level data. Guard both the
+# presence of the standalone line and the absence of the broken combined form.
+
+@test "defaults.conf emits 'report_meta level' on its own line" {
+    DEFAULTS="${BATS_TEST_DIRNAME}/../../rtl_433/rtl_433.defaults.conf"
+    grep -Eq '^[[:space:]]*report_meta[[:space:]]+level[[:space:]]*$' "$DEFAULTS"
+}
+
+@test "defaults.conf never combines 'level' with another meta type on one line" {
+    DEFAULTS="${BATS_TEST_DIRNAME}/../../rtl_433/rtl_433.defaults.conf"
+    # A report_meta line carrying 'level' plus any other whitespace-separated
+    # token would drop the level data; assert no such line exists.
+    run grep -En '^[[:space:]]*report_meta[[:space:]]+.*[[:space:]]level([[:space:]]|$)' "$DEFAULTS"
+    [ "$status" -ne 0 ]
+    [ -z "$output" ]
+}


### PR DESCRIPTION
## Problem

The baked-in default config (`rtl_433/rtl_433.defaults.conf`) emits a single combined directive:

```
report_meta time:iso:usec:tz level
```

rtl_433 only colon-combines sub-options **within one meta type**. Two different meta types cannot share a `report_meta` line, so the trailing `level` type is **silently dropped** and only the `time` meta takes effect. As a result no `frequency`/`RSSI`/`SNR`/`noise` level fields ever reach Home Assistant.

Confirmed by diagnostics: timestamps are present, but there are zero level fields in `seen_field_keys`.

## Fix

Split the two meta types onto separate lines so both apply:

```
report_meta time:iso:usec:tz
report_meta level
```

A comment is added explaining why `level` must stay on its own line, to prevent the regression from recurring.

## Testing

- `python3 tests/config/validate_configs.py` → both add-ons OK.
- No tests or scripts reference the old single-line form (grep clean).
- The `-next` add-on inherits this config via the build-time copy of the shared files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)