### PR TITLE
fix(ci): clone full history so the changelog amend keeps its parent

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -62,6 +62,15 @@ jobs:
       # usual case, since release-please regenerates the branch on every push)
       # changes nothing and the step exits without amending or pushing.
       #
+      # The clone is intentionally NOT shallow. release-please builds the release
+      # commit via the GitHub API, so its parent (main's HEAD) is a separate
+      # object. With `--depth 1` that parent is not fetched, and `git commit
+      # --amend` then rewrites the release commit into a *root* commit -- the
+      # branch loses its ancestry to main, the PR shows the entire repo as
+      # additions (no merge base), and release-please closes and recreates the
+      # PR on every run. A full clone keeps the parent object present so the
+      # amend preserves the link back to main.
+      #
       # Pushes use the App token in the clone URL, not GITHUB_TOKEN, so the
       # workflow's `permissions: {}` posture is unchanged.
       - name: Normalize CHANGELOG headings for Home Assistant
@@ -71,7 +80,7 @@ jobs:
           PR_BRANCH: ${{ fromJSON(steps.release.outputs.pr).headBranchName }}
         run: |
           set -euo pipefail
-          git clone --branch "$PR_BRANCH" --depth 1 \
+          git clone --branch "$PR_BRANCH" \
             "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" rp-branch
           cd rp-branch
           sed -i -E \


### PR DESCRIPTION
## Problem

After #86 merged, the release-please bot started **closing and recreating** its release PR on every run, and the PRs showed **~11,000 additions** (the entire repo as "new").

## Root cause

\#86 added a *Normalize CHANGELOG headings* step that clones the release PR branch, rewrites the version headings into the bare `## x.y.z` form Home Assistant wants, and **amends** the result into release-please's commit. The clone used `--depth 1`.

release-please builds its release commit through the **GitHub API**, so the commit's parent (main's `HEAD`) is a separate object. A depth-1 shallow clone fetches only the release commit and **not** its parent. With the parent object absent, `git commit --amend` rewrites the release commit into a **root commit** — the branch loses its ancestry to `main`.

Consequences, all observed on the live runs:

- The release branch (`release-please--branches--main`) had **no merge base** with `main`, so GitHub diffed two unrelated histories and rendered the whole tree (~11k lines) as additions.
- The amend log confirmed it: `112 files changed, 11225 insertions(+)` with `create mode` for every file.
- release-please saw its branch out of sync and **closed + recreated** the PR each run (#88, #89 were each created and closed within ~6 s of the same run).

## Fix

Drop `--depth 1`. With full history the parent object is present, so `--amend` preserves the link back to `main`. The branch descends from `main` as before, the PR shows only the `CHANGELOG.md` change, and the close/recreate churn stops. The repo is small, so the full clone is negligible.

Everything else is unchanged: the idempotent `sed`, the no-op early-exit, `--amend --no-edit` (single commit, release-please's message/author preserved), and the App-token push (so `permissions: {}` is intact).

## Self-heal

Merging this to `main` triggers a release-please run that force-updates the orphaned `release-please--branches--main` ref back to a healthy commit (parent = `main`), then re-applies the heading rewrite correctly. No manual branch surgery needed.

## Verification

- `actionlint` / `check-yaml` / whitespace hooks pass.
- Root cause traced directly in the run log for the failing release-please run (amend reported all 112 files as `create mode`; the pushed commit object has no `parent` line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)