### PR TITLE
fix(ci): don't evaluate fromJSON on the empty PR output during a release

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -73,13 +73,23 @@ jobs:
       #
       # Pushes use the App token in the clone URL, not GITHUB_TOKEN, so the
       # workflow's `permissions: {}` posture is unchanged.
+      #
+      # This only runs when release-please opened/updated a release PR. On a
+      # release-creation run (the PR was merged, a tag was cut) there is no PR
+      # and nothing to normalize -- the CHANGELOG was already normalized in the
+      # PR that just merged. The `if:` skips the step then, but GitHub still
+      # evaluates a step's `env:` even when its `if:` is false, so the PR JSON
+      # is passed through verbatim and parsed with jq in the script. Calling
+      # `fromJSON()` on the empty `outputs.pr` string in an `env:` expression
+      # raises a template error and fails the whole release run.
       - name: Normalize CHANGELOG headings for Home Assistant
         if: ${{ steps.release.outputs.pr }}
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          PR_BRANCH: ${{ fromJSON(steps.release.outputs.pr).headBranchName }}
+          PR_JSON: ${{ steps.release.outputs.pr }}
         run: |
           set -euo pipefail
+          PR_BRANCH="$(printf '%s' "$PR_JSON" | jq -r '.headBranchName')"
           git clone --branch "$PR_BRANCH" \
             "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" rp-branch
           cd rp-branch


### PR DESCRIPTION
## Problem

The Release Please job [failed on `main`](https://github.com/rtl-433-hass/rtl_433-hass-addons/actions/runs/26887837979/job/79305023814) on the run that cut **v0.6.1**:

```
The template is not valid. .github/workflows/release-please.yml (Line: 80, Col: 22):
Error reading JToken from JsonReader. Path '', line 0, position 0.
```

## Root cause

The *Normalize CHANGELOG headings* step is gated on a release PR existing:

```yaml
if: ${{ steps.release.outputs.pr }}
env:
  PR_BRANCH: ${{ fromJSON(steps.release.outputs.pr).headBranchName }}
```

But GitHub evaluates a step's **`env:` block even when its `if:` is false**. On a release-*creation* run — where the release PR was merged and a tag was cut — `steps.release.outputs.pr` is an **empty string**, so `fromJSON('')` throws a template error and fails the whole job *before* the `if:` can skip the step.

This is the first release-creation run since the step was introduced (#86), so it's the first time the empty-`pr` path was hit.

## Impact

Cosmetic but real: **v0.6.1 was released fine** (tag, GitHub release, and `config.json` bump all succeeded — the release-please action step runs before this one). Only the post-step crashed, turning every future release run red and masking genuine failures.

## Fix

Pass the raw PR JSON through `env:` and parse the branch with `jq` **inside the script**, so no `fromJSON()` ever runs in a template context:

```yaml
env:
  PR_JSON: ${{ steps.release.outputs.pr }}
run: |
  PR_BRANCH="$(printf '%s' "$PR_JSON" | jq -r '.headBranchName')"
```

On a release-creation run the env var is just an empty string (valid), the `if:` skips the step, and the job stays green. Normalization still only runs on release-PR runs — the only time there's a CHANGELOG entry to rewrite — which matches the intent.

## Verification

- `jq -r '.headBranchName'` correctly extracts the branch from a representative `outputs.pr` payload (incl. quotes / newlines / `$` in the body).
- `actionlint` + YAML/whitespace hooks pass.
- `jq` is preinstalled on the `ubuntu-24.04` runner image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)