### PR TITLE
fix(rtl_433): make randomize_default_serial a one-shot flash-and-halt step

### DIFF
--- a/rtl_433-next/README.md
+++ b/rtl_433-next/README.md
@@ -38,9 +38,10 @@ sweeps each radio with `rtl_power` on every boot, writing timestamped
 `noise-<id>-<timestamp>.{csv,txt,png}` reports to the add-on config directory
 (`/addon_configs/rtl433-next/`); it is a boot-time snapshot at the configured
 band(s), not the integration's runtime frequency. **Randomize default serial**
-(on by default) flashes a unique random serial onto any dongle still carrying a
-factory-default serial at startup, so multiple dongles become individually
-identifiable. See the
+(off by default) is a one-time maintenance step: when on, the add-on writes a
+unique random serial to any default-serial dongle and then halts without
+starting `rtl_433`; you turn the option back off, stop the add-on, replug the
+dongle(s), and start again to apply it. See the
 [stable add-on README](../rtl_433/README.md) for full configuration details.
 
 To update rtl_433 to the latest version, uninstall and reinstall the addon.

--- a/rtl_433-next/config.json
+++ b/rtl_433-next/config.json
@@ -14,7 +14,7 @@
   "hassio_api": true,
   "discovery": ["rtl_433"],
   "options": {
-    "randomize_default_serial": true,
+    "randomize_default_serial": false,
     "disable_tpms": true,
     "log_received_messages": false,
     "log_diagnostic_messages": false,

--- a/rtl_433/README.md
+++ b/rtl_433/README.md
@@ -127,24 +127,33 @@ The `<id>` is the radio's identifier (the same one used for override files). Bec
 
 Nearly all RTL-SDR dongles ship with the same factory-default serial
 (`00000000` or `00000001`), which makes multiple dongles indistinguishable and
-pushes the add-on to identify them by USB port instead. The **Randomize default
-serial** option (on by default) fixes this automatically: at startup, before
-any radio claims a device, the add-on flashes a **unique random 8-hex-character
-serial** onto every connected dongle that still carries a factory-default
-serial, using `rtl_eeprom`. Dongles that already have a real serial are never
-touched.
+pushes the add-on to identify them by USB port instead. When the add-on detects
+a default-serial dongle it logs a warning recommending you assign it a unique
+serial with the **Randomize default serial** option (off by default).
 
-This is a **one-time** operation: once a dongle has been given a serial it is no
-longer a factory default, so later boots find nothing to flash (even with the
-option left on) — a dongle is never re-flashed. After flashing, the add-on
-re-enumerates the dongles **once** so the new serials are used for the rest of
-that same boot — for identity, override-file matching, and launch.
+This option is a **one-time maintenance step**, not a normal runtime setting,
+because applying a new serial requires physically replugging the dongle:
+`rtl_eeprom` writes the serial to the dongle's EEPROM, but the RTL2832U only
+reads its serial at USB power-on, and the add-on's container cannot power-cycle
+the USB bus. So when the option is **on**, the add-on writes a **unique random
+8-hex-character serial** to every connected default-serial dongle and then
+**stops — it does not start `rtl_433`** — printing instructions to the log.
 
-**Caveat:** applying a new serial requires the dongle to re-enumerate (a USB
-reset). The EEPROM write always persists, but if the reset does not propagate
-inside the container on the first boot, the freshly assigned serial simply takes
-effect on the **next add-on restart**. Every step is best-effort: a failure to
-flash or re-enumerate never stops the radio (or the add-on) from starting.
+To assign serials to your dongles:
+
+1. Turn **on** *Randomize default serial* and (re)start the add-on. It writes new
+   serials to any factory-default dongles, then halts without starting `rtl_433`.
+2. Turn the option back **off**.
+3. **Stop** the add-on.
+4. **Unplug and replug** the RTL-SDR dongle(s) (or power-cycle the USB hub) so
+   they re-read their new serials.
+5. **Start** the add-on again — each dongle now reports its unique serial and is
+   identified by it (stable across USB-port changes).
+
+Dongles that already have a real serial are never touched. Every step is
+best-effort: a missing `rtl_eeprom` or a failed/rejected write is logged and
+skipped. Leaving the option on simply keeps the add-on in this maintenance mode
+(no radios start), so remember to turn it back off when you're done.
 
 ### Non-RTL-SDR radios (SoapySDR / HackRF)
 

--- a/rtl_433/config.json
+++ b/rtl_433/config.json
@@ -20,7 +20,7 @@
     "rtl_433"
   ],
   "options": {
-    "randomize_default_serial": true,
+    "randomize_default_serial": false,
     "disable_tpms": true,
     "log_received_messages": false,
     "log_diagnostic_messages": false,

--- a/rtl_433/run.sh
+++ b/rtl_433/run.sh
@@ -541,31 +541,39 @@ main() {
     # real hardware (serial / USB port path) rather than the unstable device index.
     mapfile -t rtlsdr_devices < <(enumerate_rtlsdr_devices)
 
-    # Optionally normalise factory-default serials before anything claims a
-    # device. rtl_eeprom writes persist and reset the dongle (triggering kernel
-    # re-enumeration), so flash every default-serial dongle up front and then
-    # re-enumerate once so the freshly assigned serials are used for identity,
-    # override matching, PPM, noise-floor, and launch. Best-effort throughout: a
-    # missing rtl_eeprom or a failed/ineffective flash is warned and the dongle
-    # keeps whatever identity it had.
-    if [ "$randomize_default_serial" = "true" ] && [ "${#rtlsdr_devices[@]}" -gt 0 ]
+    # When 'randomize_default_serial' is on, run a one-time MAINTENANCE pass and
+    # then halt without launching any radios. Rationale: rtl_eeprom writes the new
+    # serial to the dongle's EEPROM but does NOT reset the device, and the RTL2832U
+    # only re-reads its serial at USB power-on — so a freshly written serial can
+    # only be applied by a physical unplug/replug (or hub power-cycle), never by a
+    # re-enumeration from inside the container. Rather than guess or churn the
+    # EEPROM on every boot, we flash every default-serial dongle once, print clear
+    # instructions, and block: the user turns the option back off, stops the
+    # add-on, replugs the dongle(s), and starts again. Because we block instead of
+    # exiting, a watchdog cannot restart-loop us into re-flashing.
+    if [ "$randomize_default_serial" = "true" ]
     then
+        flashed_count=0
         if ! command -v rtl_eeprom >/dev/null 2>&1
         then
-            bashio::log.warning "randomize_default_serial is on but rtl_eeprom is not available; skipping serial randomization."
+            bashio::log.warning "randomize_default_serial is on but rtl_eeprom is not available; no serials can be written."
         else
-            flashed_any="false"
-            # Space-padded set of serials to avoid (already present + assigned).
+            # Space-padded set of serials to avoid assigning (those already present
+            # on a connected dongle, plus any picked earlier in this same pass).
             existing_serials=" "
             for entry in "${rtlsdr_devices[@]}"
             do
                 existing_serials+="${entry%%$'\t'*} "
             done
+
             for i in "${!rtlsdr_devices[@]}"
             do
                 [ "$i" -ge "$MAX_RADIOS" ] && break
                 entry="${rtlsdr_devices[$i]}"
                 serial="${entry%%$'\t'*}"
+                portpath="${entry#*$'\t'}"
+                # Only touch dongles that still carry a factory-default serial; a
+                # dongle with a real serial is left alone.
                 _serial_is_default "$serial" || continue
 
                 # Pick a random serial not already present or assigned this pass.
@@ -581,34 +589,60 @@ main() {
                 done
                 if [ -z "$new_serial" ]
                 then
-                    bashio::log.warning "Radio at index ${i}: could not generate a unique serial; leaving its default serial unchanged."
+                    bashio::log.warning "Radio at ${portpath}: could not generate a unique serial; leaving its default serial unchanged."
                     continue
                 fi
 
-                bashio::log.info "Radio at index ${i}: flashing random serial ${new_serial} (was default '${serial}')."
+                bashio::log.info "Radio at ${portpath} (index ${i}): writing random serial ${new_serial} to EEPROM (was default '${serial}')."
                 # rtl_eeprom prompts for confirmation; auto-answer 'y' and bound
                 # the call so a stuck write cannot hang startup. A non-zero exit
                 # is tolerated (best-effort).
                 if printf 'y\n' | timeout 30 rtl_eeprom -d "$i" -s "$new_serial" >/dev/null 2>&1
                 then
                     existing_serials+="${new_serial} "
-                    flashed_any="true"
+                    flashed_count=$((flashed_count + 1))
                 else
-                    bashio::log.warning "Radio at index ${i}: rtl_eeprom failed to write serial ${new_serial} (non-fatal; keeping default)."
+                    bashio::log.warning "Radio at ${portpath}: rtl_eeprom failed to write serial ${new_serial} (non-fatal)."
                 fi
             done
-
-            if [ "$flashed_any" = "true" ]
-            then
-                # The EEPROM write resets the dongle; give the kernel a moment to
-                # re-enumerate, then refresh the device list exactly once so the
-                # new serials flow through the rest of startup.
-                bashio::log.info "Re-enumerating RTL-SDR dongles after serial flash..."
-                sleep 2
-                mapfile -t rtlsdr_devices < <(enumerate_rtlsdr_devices)
-            fi
         fi
+
+        bashio::log.info "============================================================"
+        bashio::log.info "randomize_default_serial is ON — one-time maintenance mode."
+        if [ "$flashed_count" -gt 0 ]
+        then
+            bashio::log.info "Wrote a new random serial to ${flashed_count} dongle(s)."
+        else
+            bashio::log.info "No factory-default dongles found; no serials written."
+        fi
+        bashio::log.info "rtl_433 will NOT start while this option is on. To finish:"
+        bashio::log.info "  1. Turn OFF 'Randomize default serial' in the add-on options."
+        bashio::log.info "  2. Stop the add-on."
+        bashio::log.info "  3. Unplug and replug the RTL-SDR dongle(s) (or power-cycle the hub)."
+        bashio::log.info "  4. Start the add-on again."
+        bashio::log.info "============================================================"
+
+        # Block (do not launch radios, do not exit). The user stops the add-on per
+        # the message above; SIGTERM then exits cleanly.
+        trap 'exit 0' TERM INT
+        while true
+        do
+            sleep 3600 & wait "$!"
+        done
     fi
+
+    # Normal operation (option off): surface any factory-default serials so the
+    # user knows identical dongles are indistinguishable (the add-on falls back to
+    # USB-port-path identity for them) and can run the one-time randomize step.
+    for entry in "${rtlsdr_devices[@]}"
+    do
+        serial="${entry%%$'\t'*}"
+        portpath="${entry#*$'\t'}"
+        if _serial_is_default "$serial"
+        then
+            bashio::log.warning "Radio at ${portpath} has a factory-default serial ('${serial:-empty}'); multiple such dongles cannot be told apart. Enable 'Randomize default serial' once to assign it a unique serial (writes the EEPROM, then requires a physical replug)."
+        fi
+    done
 
     # Parallel arrays describing each launched radio. These are populated during port
     # assignment/launch and consumed by the Supervisor discovery step below, which


### PR DESCRIPTION
## Summary

Follow-up to the `randomize_default_serial` feature (shipped in 0.7.0). Field
testing confirmed that a written serial only becomes visible after a **physical
replug**, and that the old pass re-flashed a new serial on every restart.

**Root cause:** `rtl_eeprom -s` writes the serial to EEPROM but does **not** reset
the device; the RTL2832U only re-reads its serial at USB **power-on**. No
in-container re-enumeration (the old `sleep`+re-enumerate, or even a
`USBDEVFS_RESET` ioctl — both tested against a live container) can reload it. So
the dongle kept reporting the default serial and the pass minted a fresh one
every boot, churning the EEPROM and never converging.

## New behavior

Treat the option as a **one-time maintenance switch**, not a runtime setting:

- **Off by default** (opt-in) in both add-ons.
- **When on:** the add-on writes a unique random serial to every connected
  default-serial dongle, prints instructions, and **halts without starting
  `rtl_433`**. It blocks (rather than exiting) so a watchdog can't restart-loop it
  into re-flashing. Dongles with a real serial are never touched.
- **When off (normal operation):** logs a warning for any dongle still carrying a
  factory-default serial, recommending the one-time randomize step.

### Workflow

1. Turn **on** *Randomize default serial* and (re)start → it writes serials, then
   halts.
2. Turn the option back **off**.
3. **Stop** the add-on.
4. **Unplug/replug** the dongle(s) (or power-cycle the hub).
5. **Start** again → each dongle reports its unique serial and is identified by it.

## Changes

- `run.sh`: flash-all-defaults-then-halt maintenance pass; block instead of exit;
  default-serial detection warning in normal mode. Removed the ineffective
  post-flash re-enumeration and the incorrect "EEPROM write resets the dongle"
  comment.
- `config.json` (both add-ons): default `false`. Stays first in the Configuration
  tab.
- READMEs (both): document the maintenance-step workflow and the replug
  requirement.

## Testing

- `bats -r tests/` — 40 pass (the pass relies only on already-tested helpers
  `_serial_is_default` / `generate_random_serial`).
- `python3 tests/config/validate_configs.py` — both configs valid.
- `shellcheck rtl_433/run.sh` — clean.
- Manually confirmed on hardware: after flashing, unplugging/replugging the
  dongles makes the new serials appear.
