### PR TITLE
fix(rtl_433): read EEPROM serials when the device banner omits SN

### DIFF
--- a/rtl_433/run.sh
+++ b/rtl_433/run.sh
@@ -126,6 +126,20 @@ list_rtlsdr_banner() {
     timeout 15 rtl_eeprom 2>&1
 }
 
+# Read one dongle's USB serial by opening it through its librtlsdr index. Some
+# librtlsdr builds list devices in the enumeration banner WITHOUT a serial (just
+# "  0:  Generic RTL2832U OEM"); the serial only appears once the device is
+# opened, in rtl_eeprom's 'Current configuration' dump as a 'Serial number:'
+# line. Opening by '-d <index>' resolves the index through the SAME librtlsdr
+# path the EEPROM write uses, so the serial read here and the serial written by
+# the flasher target the same dongle. Prints the serial (empty if none); the
+# timeout guards a wedged read and a non-zero exit is tolerated. Args: <index>.
+read_rtlsdr_serial_by_index() {
+    timeout 15 rtl_eeprom -d "$1" 2>&1 \
+        | sed -n 's/^Serial number:[[:space:]]*\([^[:space:]]*\).*/\1/p' \
+        | head -n 1
+}
+
 # Print librtlsdr's OWN device enumeration, one "index<TAB>serial" line per
 # device, in the exact order that 'rtl_eeprom -d <index>' / 'rtl_test -d <index>'
 # resolve. librtlsdr derives this index from libusb's device list, which is NOT
@@ -134,13 +148,19 @@ list_rtlsdr_banner() {
 # it writes is the same dongle whose serial it inspected. A blank serial (no USB
 # serial descriptor) is preserved as an empty field.
 enumerate_rtlsdr_by_index() {
-    local line
+    local line idx
     while IFS= read -r line
     do
         # Banner rows look like "  0:  Realtek, RTL2838UHIDIR, SN: 00000001".
         if [[ "$line" =~ ^[[:space:]]*([0-9]+):.*SN:[[:space:]]*([^[:space:],]*) ]]
         then
             printf '%s\t%s\n' "${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}"
+        # Other builds omit the serial from the banner ("  0:  Generic RTL2832U
+        # OEM"); fall back to opening the device to read its serial directly.
+        elif [[ "$line" =~ ^[[:space:]]*([0-9]+): ]]
+        then
+            idx="${BASH_REMATCH[1]}"
+            printf '%s\t%s\n' "$idx" "$(read_rtlsdr_serial_by_index "$idx")"
         fi
     done < <(list_rtlsdr_banner)
 }

--- a/tests/rtl_433/test_run.bats
+++ b/tests/rtl_433/test_run.bats
@@ -92,6 +92,77 @@ EOF
     [ "${lines[1]}" = "$(printf '1\tcafe1234')" ]
 }
 
+# Regression: some librtlsdr builds list devices in the banner WITHOUT a serial
+# (just "  0:  Generic RTL2832U OEM"). The old SN-only regex matched nothing, so
+# the flasher saw zero factory-default dongles. Each such row must fall back to
+# opening the device by index to read its serial.
+@test "enumerate_rtlsdr_by_index opens devices when the banner omits the serial" {
+    list_rtlsdr_banner() {
+        cat <<'EOF'
+Found 3 device(s):
+  0:  Generic RTL2832U OEM
+  1:  Generic RTL2832U OEM
+  2:  Generic RTL2832U OEM
+EOF
+    }
+    # The fallback opens 'rtl_eeprom -d <idx>' and parses 'Serial number:'.
+    read_rtlsdr_serial_by_index() {
+        case "$1" in
+            0) printf '00000001' ;;
+            1) printf '00000001' ;;
+            2) printf 'deadbeef' ;;
+        esac
+    }
+    run enumerate_rtlsdr_by_index
+    [ "$status" -eq 0 ]
+    [ "${lines[0]}" = "$(printf '0\t00000001')" ]
+    [ "${lines[1]}" = "$(printf '1\t00000001')" ]
+    [ "${lines[2]}" = "$(printf '2\tdeadbeef')" ]
+}
+
+# A banner mixing SN-bearing and SN-less rows must read each correctly: the
+# fast path off the banner, the fallback by opening the device.
+@test "enumerate_rtlsdr_by_index mixes banner serials and opened-device serials" {
+    list_rtlsdr_banner() {
+        cat <<'EOF'
+Found 2 device(s):
+  0:  Generic RTL2832U OEM
+  1:  Realtek, RTL2832U, SN: deadbeef
+EOF
+    }
+    read_rtlsdr_serial_by_index() { [ "$1" = "0" ] && printf '00000001'; }
+    run enumerate_rtlsdr_by_index
+    [ "$status" -eq 0 ]
+    [ "${lines[0]}" = "$(printf '0\t00000001')" ]
+    [ "${lines[1]}" = "$(printf '1\tdeadbeef')" ]
+}
+
+@test "read_rtlsdr_serial_by_index extracts the serial from the config dump" {
+    timeout() { shift; "$@"; }
+    rtl_eeprom() {
+        cat <<'EOF'
+Found 3 device(s):
+  0:  Generic RTL2832U OEM
+
+Using device 0: Generic RTL2832U OEM
+Found Rafael Micro R820T tuner
+
+Current configuration:
+__________________________________________
+Vendor ID:		0x0bda
+Product ID:		0x2838
+Manufacturer:		Realtek
+Product:		RTL2838UHIDIR
+Serial number:		00000001
+Serial number enabled:	yes
+__________________________________________
+EOF
+    }
+    run read_rtlsdr_serial_by_index 0
+    [ "$status" -eq 0 ]
+    [ "$output" = "00000001" ]
+}
+
 @test "_portpath_for_serial returns the port path for a unique serial" {
     rtlsdr_devices=(
         "$(printf 'deadbeef\t1-1.2')"


### PR DESCRIPTION
## Problem

The `randomize_default_serial` maintenance pass reported **"No factory-default dongles found; no serials written"** even with three factory-default (`00000001`) dongles connected.

`enumerate_rtlsdr_by_index` parses the `rtl_eeprom` enumeration banner and only matched rows that carry an `SN: <serial>` field. Some librtlsdr builds list devices **without** a serial in the banner:

```
Found 3 device(s):
  0:  Generic RTL2832U OEM
  1:  Generic RTL2832U OEM
  2:  Generic RTL2832U OEM
```

On those builds the regex matched zero rows, the flasher loop iterated over nothing, and the add-on refused to write any serial. The serial is only exposed once a device is opened (`rtl_eeprom -d <index>` → `Serial number: 00000001` in the config dump).

## Fix

When a banner row lacks an `SN:` field, fall back to opening that device by index and parsing the `Serial number:` line:

- New `read_rtlsdr_serial_by_index <idx>` helper.
- `enumerate_rtlsdr_by_index` keeps the fast SN-from-banner path and uses the fallback for bare `N:` rows.

Opening by `-d <index>` resolves through the **same** librtlsdr path the EEPROM write uses, so the read and the write target the same dongle — preserving the wrong-radio invariant from the earlier index-pinning fix.

## Tests

`bats -r tests/` — 49 pass (3 new: SN-less banner, mixed banner, `read_rtlsdr_serial_by_index` extraction). shellcheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)