### PR TITLE
fix(rtl_433): avoid USB-claim races in the EEPROM serial flasher

### DIFF
--- a/rtl_433/run.sh
+++ b/rtl_433/run.sh
@@ -37,6 +37,14 @@ RADIO_RESTART_MIN_DELAY=2
 RADIO_RESTART_MAX_DELAY=60
 RADIO_HEALTHY_UPTIME=60
 
+# The 'randomize_default_serial' maintenance pass writes each dongle's EEPROM via
+# 'rtl_eeprom -d <index>'. Opening a dongle can transiently fail to claim the USB
+# interface when several identical dongles are addressed in quick succession, so
+# a failed write is retried up to EEPROM_WRITE_ATTEMPTS times, pausing
+# EEPROM_WRITE_RETRY_DELAY seconds between tries to let the bus settle.
+EEPROM_WRITE_ATTEMPTS=3
+EEPROM_WRITE_RETRY_DELAY=2
+
 # Base sysfs path for USB device enumeration. Overridable so the enumeration can
 # be exercised against a mock tree in tests.
 SYSFS_USB_BASE="${SYSFS_USB_BASE:-/sys/bus/usb/devices}"
@@ -148,7 +156,13 @@ read_rtlsdr_serial_by_index() {
 # it writes is the same dongle whose serial it inspected. A blank serial (no USB
 # serial descriptor) is preserved as an empty field.
 enumerate_rtlsdr_by_index() {
-    local line idx
+    local banner line idx
+    # Capture the banner in full BEFORE iterating: list_rtlsdr_banner opens
+    # device 0 to read it, so streaming it via process substitution would let
+    # that 'rtl_eeprom' still hold the device while read_rtlsdr_serial_by_index
+    # tries to open the same one — a USB-claim collision that yields an empty
+    # serial. Letting the lister exit first keeps at most one open at a time.
+    banner="$(list_rtlsdr_banner)"
     while IFS= read -r line
     do
         # Banner rows look like "  0:  Realtek, RTL2838UHIDIR, SN: 00000001".
@@ -162,7 +176,7 @@ enumerate_rtlsdr_by_index() {
             idx="${BASH_REMATCH[1]}"
             printf '%s\t%s\n' "$idx" "$(read_rtlsdr_serial_by_index "$idx")"
         fi
-    done < <(list_rtlsdr_banner)
+    done <<< "$banner"
 }
 
 # Best-effort: print the sysfs port path of the connected dongle carrying the
@@ -242,7 +256,7 @@ generate_random_serial() {
 # flashed to stdout; all human-facing messages go through bashio (stderr).
 flash_default_serials() {
     local existing_serials=" " entry idx serial portpath new_serial cand
-    local flashed_count=0
+    local flashed_count=0 enumeration attempt wrote
 
     # Serials already present on a connected dongle, plus any picked earlier in
     # this same pass, so a freshly generated serial can never collide.
@@ -250,6 +264,13 @@ flash_default_serials() {
     do
         existing_serials+="${entry%%$'\t'*} "
     done
+
+    # Enumerate FULLY before writing anything: enumerate_rtlsdr_by_index opens
+    # each dongle to read its serial, so streaming it into this loop would let a
+    # read 'rtl_eeprom' overlap a write 'rtl_eeprom' on the same USB bus and
+    # transiently fail to claim a device. Capturing the result first guarantees
+    # all reads finish before the first write begins — at most one open at a time.
+    enumeration="$(enumerate_rtlsdr_by_index)"
 
     while IFS=$'\t' read -r idx serial
     do
@@ -280,15 +301,31 @@ flash_default_serials() {
 
         bashio::log.info "Radio at index ${idx}${portpath:+ (${portpath})}: writing random serial ${new_serial} to EEPROM (was default '${serial}')."
         # rtl_eeprom prompts for confirmation; auto-answer 'y' and bound the call
-        # so a stuck write cannot hang startup. A non-zero exit is tolerated.
-        if printf 'y\n' | timeout 30 rtl_eeprom -d "$idx" -s "$new_serial" >/dev/null 2>&1
+        # so a stuck write cannot hang startup. A failed open is usually a
+        # transient USB-claim collision, so retry a few times with a settle pause
+        # before giving up on this dongle.
+        wrote=0
+        for attempt in $(seq 1 "$EEPROM_WRITE_ATTEMPTS")
+        do
+            if printf 'y\n' | timeout 30 rtl_eeprom -d "$idx" -s "$new_serial" >/dev/null 2>&1
+            then
+                wrote=1
+                break
+            fi
+            if [ "$attempt" -lt "$EEPROM_WRITE_ATTEMPTS" ]
+            then
+                bashio::log.warning "Radio at index ${idx}: EEPROM write attempt ${attempt} failed; retrying in ${EEPROM_WRITE_RETRY_DELAY}s."
+                sleep "$EEPROM_WRITE_RETRY_DELAY"
+            fi
+        done
+        if [ "$wrote" -eq 1 ]
         then
             existing_serials+="${new_serial} "
             flashed_count=$((flashed_count + 1))
         else
-            bashio::log.warning "Radio at index ${idx}: rtl_eeprom failed to write serial ${new_serial} (non-fatal)."
+            bashio::log.warning "Radio at index ${idx}: rtl_eeprom failed to write serial ${new_serial} after ${EEPROM_WRITE_ATTEMPTS} attempts (non-fatal)."
         fi
-    done < <(enumerate_rtlsdr_by_index)
+    done <<< "$enumeration"
 
     printf '%s' "$flashed_count"
 }

--- a/tests/rtl_433/test_run.bats
+++ b/tests/rtl_433/test_run.bats
@@ -240,6 +240,64 @@ EOF
     [ ! -s "$RTL_EEPROM_LOG" ]                            # rtl_eeprom never called
 }
 
+# Regression: a transient USB-claim collision makes the first 'rtl_eeprom' open
+# fail. The flasher must retry (after a settle pause) rather than dropping the
+# dongle at its factory-default serial.
+@test "flash_default_serials retries a transient EEPROM write failure" {
+    rtlsdr_devices=("$(printf '00000001\t1-1.4')")
+    list_rtlsdr_banner() {
+        printf 'Found 1 device(s):\n  0:  Realtek, RTL2832U, SN: 00000001\n'
+    }
+    timeout() { shift; "$@"; }
+    generate_random_serial() { printf 'a1b2c3d4'; }
+    bashio::log.info()    { :; }
+    bashio::log.warning() { :; }
+    SLEEP_LOG="$BATS_TEST_TMPDIR/sleep.calls"
+    : > "$SLEEP_LOG"
+    sleep() { printf '%s\n' "$1" >> "$SLEEP_LOG"; }
+    ATTEMPT_FILE="$BATS_TEST_TMPDIR/attempts"
+    printf '0' > "$ATTEMPT_FILE"
+    # Fail the first open, succeed on the second. The counter lives in a file so
+    # it survives the pipeline subshell ('printf | timeout rtl_eeprom').
+    rtl_eeprom() {
+        local n
+        n=$(( $(cat "$ATTEMPT_FILE") + 1 ))
+        printf '%s' "$n" > "$ATTEMPT_FILE"
+        [ "$n" -ge 2 ]
+    }
+
+    run flash_default_serials
+    [ "$status" -eq 0 ]
+    [ "$output" = "1" ]                       # dongle flashed after the retry
+    [ "$(cat "$ATTEMPT_FILE")" = "2" ]        # took exactly two attempts
+    [ "$(cat "$SLEEP_LOG")" = "2" ]           # paused once (EEPROM_WRITE_RETRY_DELAY)
+}
+
+# Regression: when every attempt fails the flasher gives up after exactly
+# EEPROM_WRITE_ATTEMPTS tries and reports the dongle as not flashed.
+@test "flash_default_serials gives up after EEPROM_WRITE_ATTEMPTS failures" {
+    rtlsdr_devices=("$(printf '00000001\t1-1.4')")
+    list_rtlsdr_banner() {
+        printf 'Found 1 device(s):\n  0:  Realtek, RTL2832U, SN: 00000001\n'
+    }
+    timeout() { shift; "$@"; }
+    generate_random_serial() { printf 'a1b2c3d4'; }
+    bashio::log.info()    { :; }
+    bashio::log.warning() { :; }
+    SLEEP_LOG="$BATS_TEST_TMPDIR/sleep.calls"
+    : > "$SLEEP_LOG"
+    sleep() { printf '%s\n' "$1" >> "$SLEEP_LOG"; }
+    CALL_LOG="$BATS_TEST_TMPDIR/calls"
+    : > "$CALL_LOG"
+    rtl_eeprom() { printf 'x' >> "$CALL_LOG"; return 1; }   # always fails
+
+    run flash_default_serials
+    [ "$status" -eq 0 ]
+    [ "$output" = "0" ]                       # nothing flashed
+    [ "$(cat "$CALL_LOG")" = "xxx" ]          # tried EEPROM_WRITE_ATTEMPTS (3) times
+    [ "$(grep -c . "$SLEEP_LOG")" -eq 2 ]     # paused between attempts (3 - 1)
+}
+
 # --- _serial_is_usable -------------------------------------------------------
 
 @test "_serial_is_usable rejects placeholders, short ints, empty, and duplicates" {


### PR DESCRIPTION
## Problem

With `randomize_default_serial` enabled and several identical factory-default dongles connected, one dongle intermittently failed to flash:

```
INFO: Radio at index 0: writing random serial 91266c84 to EEPROM (was default '').
WARNING: Radio at index 0: rtl_eeprom failed to write serial 91266c84 (non-fatal).
```

Two tells in that log: the serial read came back **empty** (`was default ''` instead of `00000001`), and the **write failed** — yet the exact same `rtl_eeprom -d 0 -s ...` succeeds when run by hand. So it's not the EEPROM; it's a transient USB-claim collision (libusb `EBUSY`).

The maintenance pass opens each dongle several times in quick succession, and two of those opens could run **concurrently**:

- `enumerate_rtlsdr_by_index` streamed `list_rtlsdr_banner` via process substitution, so the banner's `rtl_eeprom` (which opens device 0) could still hold the device while `read_rtlsdr_serial_by_index` tried to open the same one → empty serial.
- `flash_default_serials` streamed `enumerate_rtlsdr_by_index` into its write loop, so a read `rtl_eeprom` for the next index could overlap the write `rtl_eeprom` for the current one.

Each `rtl_eeprom` re-enumerates the whole USB bus, so two alive at once is enough to fail an interface claim. The on-screen "done" steps then told the user to turn the option off and replug, silently leaving one dongle at `00000001`.

## Fix

1. **Eliminate the overlap** — materialise each enumeration in full before consuming it (`banner="$(list_rtlsdr_banner)"` and `enumeration="$(enumerate_rtlsdr_by_index)"`), so at most one `rtl_eeprom` is open at any moment.
2. **Retry the write** up to `EEPROM_WRITE_ATTEMPTS` (3) times with `EEPROM_WRITE_RETRY_DELAY` (2s) between tries, so a residual transient collision self-heals instead of dropping a dongle.

The read/write index lock-step from the earlier fix is preserved — capturing the enumeration doesn't change the ordering, only its timing.

## Tests

`bats -r tests/` — 51 pass (2 new: retry-then-succeed, and exhaust-all-attempts). shellcheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)