### PR TITLE
docs: link the add-on's integration reference to its published docs

### DIFF
--- a/rtl_433/README.md
+++ b/rtl_433/README.md
@@ -2,7 +2,7 @@
 
 This add-on runs [rtl_433](https://github.com/merbanan/rtl_433) under the Home Assistant Supervisor so Home Assistant can receive wireless sensor data from SDR radios.
 
-It works with no file editing for the common case: install the add-on, plug in one or more RTL-SDR dongles, start it, then connect the companion [rtl_433 Home Assistant integration](https://github.com/rtl-433-hass/rtl_433) to each radio's WebSocket endpoint.
+It works with no file editing for the common case: install the add-on, plug in one or more RTL-SDR dongles, start it, then connect the companion [rtl_433 Home Assistant integration](https://rtl-433-hass.github.io/rtl_433/latest/) to each radio's WebSocket endpoint.
 
 ## Documentation
 


### PR DESCRIPTION
## Summary

Points the add-on README's companion-integration link at the now-live integration docs site (`https://rtl-433-hass.github.io/rtl_433/latest/`) instead of the GitHub repo, matching the integration links used throughout the docs site.

It also carries a **`Release-As: 0.8.1`** footer to cut a maintenance release. That's the real goal: the resulting **`v0.8.1` tag** is what triggers `docs.yml` to publish the versioned add-on docs and the **`latest`** alias (a `v*.*.*` tag is the only thing that does — pushes to `main` only publish `dev`).

This commit touches `rtl_433/` on purpose: the `rtl_433`-scoped release-please package never sees changes under `docs/`, so the release trigger has to live in a `rtl_433/`-touching commit.

## What happens after merge
1. Merge this PR → release-please sees `Release-As: 0.8.1` and opens a **release PR** (`chore(main): release 0.8.1`).
2. Merge that release PR → tags **`v0.8.1`**, bumps `rtl_433/config.json`, updates `rtl_433/CHANGELOG.md`.
3. The tag triggers `docs.yml` → `mike deploy 0.8 latest` + `set-default latest` → **`/latest/` and the docs root go live**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)