### PR TITLE
docs: recommend integration-first setup order for add-on discovery

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 
 These add-ons run [rtl_433](https://github.com/merbanan/rtl_433) under the Home Assistant Supervisor so Home Assistant can receive data from wireless sensors through software-defined radio (SDR) receivers.
 
-The default add-on works with no file editing: install it, plug in one or more RTL-SDR dongles, start the add-on, and connect the companion [rtl_433 Home Assistant integration](https://rtl-433-hass.github.io/rtl_433/latest/) to the radio WebSocket endpoints.
+The default add-on works with no file editing: install the companion [rtl_433 Home Assistant integration](https://rtl-433-hass.github.io/rtl_433/latest/) and restart Home Assistant, then install this add-on, plug in one or more RTL-SDR dongles, and start it. Each radio is discovered automatically in Home Assistant — no connection details to type.
 
 ## Add-ons
 
@@ -15,7 +15,7 @@ The default add-on works with no file editing: install it, plug in one or more R
 
 On startup the add-on auto-detects every connected RTL-SDR dongle and launches one rtl_433 process per radio. (Throughout these docs, a *radio* is a single rtl_433 process bound to one device — usually a dongle, but also a manually declared SoapySDR or HackRF device.) Each radio gets an HTTP/WebSocket endpoint with a predictable TCP port starting at `8433`; the second radio gets `8434`, and so on, up to the configured port range.
 
-The add-on publishes Supervisor discovery data for each radio on a best-effort basis. The companion integration consumes that discovery data when available, or you can add the integration manually with the add-on host, port, and `/ws` path.
+The add-on publishes Supervisor discovery data for each radio on a best-effort basis. The companion integration consumes that discovery data when available — install the integration and restart Home Assistant before starting the add-on so the integration is loaded when discovery is published — or you can add a hub manually with the add-on host, port, and `/ws` path.
 
 ## Start Here
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -7,12 +7,16 @@ You need:
 1. Home Assistant OS or another Supervisor-based installation that supports add-ons.
 2. An SDR supported by rtl_433, usually an RTL-SDR USB dongle.
 3. Wireless sensors supported by rtl_433.
-4. The companion [rtl_433 Home Assistant integration](https://rtl-433-hass.github.io/rtl_433/latest/) to create Home Assistant devices and entities from the decoded data.
+4. The companion [rtl_433 Home Assistant integration](https://rtl-433-hass.github.io/rtl_433/latest/) to create Home Assistant devices and entities from the decoded data. Install it [before starting the add-on](#install-the-integration-first).
 
 The upstream rtl_433 hardware and protocol references are useful when choosing radios and sensors:
 
 - [rtl_433 hardware documentation](https://triq.org/rtl_433/HARDWARE.html)
 - [rtl_433 supported protocols](https://github.com/merbanan/rtl_433/blob/master/README.md)
+
+## Install the Integration First
+
+Install the companion [rtl_433 integration](https://rtl-433-hass.github.io/rtl_433/latest/installation/) and restart Home Assistant *before* starting the add-on. The order matters: the add-on publishes Supervisor discovery data for each radio when it starts, and the discovered **rtl_433** cards only appear if the integration is already loaded. With the integration in place first, every radio shows up under **Settings -> Devices & Services** ready to add with one click — no host or port needs to be typed.
 
 ## Add the Repository
 
@@ -38,7 +42,9 @@ The log writes the override path as `/config/<id>.conf`. That is the path *insid
 
 ## Connect Home Assistant
 
-Install the companion [rtl_433 integration](https://rtl-433-hass.github.io/rtl_433/latest/) and add one hub per radio. The default connection values are:
+If the [integration was installed first](#install-the-integration-first), each detected radio appears as a discovered **rtl_433** card under **Settings -> Devices & Services**. Click **Add** and confirm — that's it.
+
+If no discovery card appears (for example, the integration was installed after the add-on started), install the integration, restart Home Assistant, and then restart the add-on so it republishes discovery. Alternatively, add one hub per radio manually with these values:
 
 | Field | Value |
 | --- | --- |

--- a/rtl_433/README.md
+++ b/rtl_433/README.md
@@ -2,7 +2,7 @@
 
 This add-on runs [rtl_433](https://github.com/merbanan/rtl_433) under the Home Assistant Supervisor so Home Assistant can receive wireless sensor data from SDR radios.
 
-It works with no file editing for the common case: install the add-on, plug in one or more RTL-SDR dongles, start it, then connect the companion [rtl_433 Home Assistant integration](https://rtl-433-hass.github.io/rtl_433/latest/) to each radio's WebSocket endpoint.
+It works with no file editing for the common case: install the companion [rtl_433 Home Assistant integration](https://rtl-433-hass.github.io/rtl_433/latest/) and restart Home Assistant, then install this add-on, plug in one or more RTL-SDR dongles, and start it. Each radio is discovered automatically in Home Assistant.
 
 ## Documentation
 
@@ -18,10 +18,11 @@ Key pages:
 
 ## Quick Start
 
-1. Install this add-on from `https://github.com/rtl-433-hass/rtl_433-hass-addons`.
-2. Plug the SDR dongle or dongles into the Home Assistant host.
-3. Start the add-on.
-4. Check the add-on log for each radio's host, port, and stable `unique_id`.
-5. Add the companion rtl_433 integration in Home Assistant and connect it to each radio. The first radio usually uses port `8433` and path `/ws`.
+1. Install the companion [rtl_433 integration](https://rtl-433-hass.github.io/rtl_433/latest/installation/) and restart Home Assistant. Doing this *before* starting the add-on is what makes autodiscovery work.
+2. Install this add-on from `https://github.com/rtl-433-hass/rtl_433-hass-addons`.
+3. Plug the SDR dongle or dongles into the Home Assistant host.
+4. Start the add-on.
+5. Each detected radio appears as a discovered **rtl_433** card under **Settings -> Devices & Services** — click **Add** and confirm.
+6. If no card appears, check the add-on log for each radio's host, port, and stable `unique_id` and add a hub manually. The first radio usually uses port `8433` and path `/ws`.
 
 Per-radio override files live in the add-on config directory, reachable as `/addon_configs/rtl433/`. The add-on log prints the exact `<id>.conf` filename for each detected radio.


### PR DESCRIPTION
Document the ideal workflow: install the companion integration via HACS, restart Home Assistant, then install and start the add-on, so the integration is loaded when the add-on publishes Supervisor discovery and each radio appears as a discovered card. Lead the Connect Home Assistant section with the discovery card and demote manual host/port entry to a fallback.


Claude-Session: https://claude.ai/code/session_018vbAvBzZoSregVGzP5sTH7