### PR TITLE
ci: track upstream master in the -next build again

### DIFF
--- a/.github/workflows/build-addon.yml
+++ b/.github/workflows/build-addon.yml
@@ -119,15 +119,37 @@ jobs:
       env:
         ADDON: ${{ matrix.addon }}
         ARCH: ${{ matrix.arch }}
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         # The legacy home-assistant/builder action read build.json implicitly.
         # build-image only injects BUILD_ARCH/BUILD_VERSION, so pass BUILD_FROM
         # and any extra build args (e.g. rtl433GitRevision) from build.json here.
         build_from=$(jq -r --arg arch "${ARCH}" '.build_from[$arch]' "${ADDON}/build.json")
+
+        # The -next channel pins rtl433GitRevision to a moving ref ("master").
+        # Resolve it to the current upstream commit SHA so the Docker build cache
+        # key changes whenever master advances — otherwise the cached clone and
+        # compile layers freeze -next at a stale commit. A 40-hex SHA or a
+        # release tag (stable channel) passes through unchanged.
+        revision=$(jq -r '.args.rtl433GitRevision // empty' "${ADDON}/build.json")
+        if [ -n "${revision}" ] && ! printf '%s' "${revision}" | grep -Eq '^[0-9a-f]{40}$'; then
+          resolved=$(curl -fsSL \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H "Accept: application/vnd.github.sha" \
+            "https://api.github.com/repos/merbanan/rtl_433/commits/${revision}")
+          echo "Resolved merbanan/rtl_433 ${revision} -> ${resolved}"
+          revision="${resolved}"
+        fi
+
         {
           echo "build_args<<EOF"
           echo "BUILD_FROM=${build_from}"
-          jq -r '.args // {} | to_entries[] | "\(.key)=\(.value)"' "${ADDON}/build.json"
+          jq -r '.args // {} | to_entries[]
+                 | select(.key != "rtl433GitRevision")
+                 | "\(.key)=\(.value)"' "${ADDON}/build.json"
+          if [ -n "${revision}" ]; then
+            echo "rtl433GitRevision=${revision}"
+          fi
           echo "EOF"
         } >> "$GITHUB_OUTPUT"
 

--- a/rtl_433/Dockerfile
+++ b/rtl_433/Dockerfile
@@ -25,13 +25,18 @@ WORKDIR /build
 
 FROM builder AS rtl_433_builder
 
-RUN git clone https://github.com/merbanan/rtl_433
-WORKDIR /build/rtl_433
-
-# Build a specific commit or tag.
+# Build a specific commit, tag, or branch tip. CI resolves and passes the
+# current upstream commit SHA for the -next channel (whose build.json pins the
+# moving "master" ref) so this layer's build cache invalidates whenever master
+# advances; the stable channel defaults to a pinned release tag.
 ARG rtl433GitRevision=25.12
+# Clone and checkout in a single layer that references the revision so a new
+# revision busts the whole source fetch. Splitting them lets the build cache
+# reuse a stale clone — freezing the upstream source at the clone layer's cached
+# commit (or failing when checked out to a commit that clone predates).
 # hadolint ignore=DL3059
-RUN git checkout ${rtl433GitRevision}
+RUN git clone https://github.com/merbanan/rtl_433 \
+    && git -C rtl_433 checkout ${rtl433GitRevision}
 WORKDIR /build/rtl_433/build
 # hadolint ignore=DL3059
 RUN cmake ..


### PR DESCRIPTION
The -next channel is meant to rebuild rtl_433 from the tip of
merbanan/rtl_433 master each night, but its published image had frozen at
a 2026-06-16 build: every nightly reported green while shipping identical,
stale bits (verified from the registry — both arches' image config and the
compiled-binary layer are dated 2026-06-16).

Root cause: commit 8206794 migrated the reusable build workflow from the
uncached home-assistant/builder@master action to build-image with a
persistent registry layer cache (cache-image-tag). Because the Dockerfile
fetches master with byte-identical `git clone` / `git checkout master`
instructions, BuildKit treats the clone and compile layers as cache hits
forever, so master never advances.

Make the source-fetch layer's cache key depend on the actual upstream
commit:

- build-addon.yml resolves a moving rtl433GitRevision ref (the -next
  channel pins "master") to the current upstream commit SHA and passes
  that as the build arg. A 40-hex SHA or a release tag (stable channel)
  passes through unchanged.
- The Dockerfile folds the clone and checkout into a single layer that
  references the revision, so a new SHA busts the whole source fetch and a
  cached clone can never be checked out to a commit it predates.

master unchanged -> cache hit (fast); master advanced -> rebuild that day.
The cosign/cache speedups are retained and each -next build is pinned to a
reproducible commit.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KbzmzVmZ25Y4phXUuqJKNa