### PR TITLE
ci: track home-assistant base image in build.json via renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,9 +9,29 @@
     {
       "matchPackageNames": ["merbanan/rtl_433"],
       "semanticCommitType": "feat"
+    },
+    {
+      "matchDatasources": ["docker"],
+      "matchPackageNames": [
+        "ghcr.io/home-assistant/amd64-base",
+        "ghcr.io/home-assistant/aarch64-base"
+      ],
+      "groupName": "home-assistant base image"
     }
   ],
   "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^rtl_433/build\\.json$/",
+        "/^rtl_433-next/build\\.json$/",
+        "/^\\.github/workflows/smoke-tests\\.yml$/"
+      ],
+      "matchStrings": [
+        "(?<depName>ghcr\\.io/home-assistant/[a-z0-9]+-base):(?<currentValue>[0-9]+\\.[0-9]+)"
+      ],
+      "datasourceTemplate": "docker"
+    },
     {
       "customType": "regex",
       "managerFilePatterns": ["/^\\.pre-commit-config\\.yaml$/"],


### PR DESCRIPTION
Renovate's built-in Dockerfile manager bumps the ARG BUILD_FROM default
in rtl_433/Dockerfile, but the CI build (build-addon.yml) reads BUILD_FROM
from each add-on's build.json and passes it as a --build-arg, overriding
the Dockerfile default. The build.json base-image pins were not covered by
any Renovate manager, so the images that actually ship were never updated
and had drifted behind the Dockerfile default.

Add a regex custom manager covering the build_from pins in both build.json
files and the hardcoded pin in smoke-tests.yml, and group all
ghcr.io/home-assistant/*-base docker updates (including the Dockerfile ARG)
into one PR so every base-image reference moves in lockstep.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WSQ3GmrvATTYCzs8BqU1P5