### PR TITLE
chore(renovate): split github-actions updates by updateType

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,8 @@
     ":preserveSemverRanges",
     "helpers:pinGitHubActionDigests"
   ],
+  "internalChecksFilter": "strict",
+  "minimumReleaseAgeBehaviour": "timestamp-required",
   "packageRules": [
     {
       "matchPackageNames": ["merbanan/rtl_433"],
@@ -17,6 +19,28 @@
         "ghcr.io/home-assistant/aarch64-base"
       ],
       "groupName": "home-assistant base image"
+    },
+    {
+      "description": "Tagged action releases: cooldown, then automerge",
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "minimumReleaseAge": "3 days",
+      "automerge": true,
+      "automergeType": "pr"
+    },
+    {
+      "description": "Major action bumps: cooldown, manual review",
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["major"],
+      "minimumReleaseAge": "3 days",
+      "automerge": false
+    },
+    {
+      "description": "Pure digest moves: no timestamp available, always review",
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["digest", "pinDigest", "pin"],
+      "automerge": false,
+      "dependencyDashboardApproval": true
     }
   ],
   "customManagers": [


### PR DESCRIPTION
## Summary

Ports the Renovate GitHub Actions handling from [deviantintegral/flame_connect_ha#125](https://github.com/deviantintegral/flame_connect_ha/pull/125) to this add-on repo, adapted to its existing `renovate.json`.

- Add top-level `internalChecksFilter: strict` and `minimumReleaseAgeBehaviour: timestamp-required`, so an update with no resolvable release timestamp is blocked rather than automerged (the safe failure). (`helpers:pinGitHubActionDigests` was already present.)
- Add GitHub Actions rules split by update type (the repo previously had no `github-actions` package rule):

| Update type | Cooldown | Behavior |
| --- | --- | --- |
| `minor` / `patch` | 3 days | automerge via PR (waits for status checks) |
| `major` | 3 days | manual review |
| `digest` / `pinDigest` / `pin` | — | queued behind dependency dashboard approval |

The existing `merbanan/rtl_433` and Home Assistant base-image rules and all custom managers are unchanged.

## Alternatives Considered

This repo had no automerge configured anywhere, so the `minor`/`patch` rule newly **enables** automerge for those GitHub Action updates. The alternative was to keep `automerge: false` for all action updates and take only the cooldown/digest-approval pieces. This PR follows the source PR faithfully to keep the org's Renovate behavior consistent; if automerging minor/patch action bumps is not wanted here, that rule can be flipped to `automerge: false`.

## Testing Steps

1. `python3 -c "import json; json.load(open('renovate.json'))"` — confirms the config is valid JSON.
2. Renovate validates the config on its next run; the `github-actions` manager updates then follow the split rules above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)